### PR TITLE
Add random favorite activity and fix pagination bug in favorites

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -176,6 +176,9 @@
             android:configChanges="orientation|screenSize"
             android:parentActivityName=".MainActivity" />
         <activity
+            android:name=".RandomFavoriteActivity"
+            android:parentActivityName=".FavoriteActivity" />
+        <activity
             android:name=".CopyToClipboardActivity"
             android:icon="@drawable/ic_content_copy"
             android:label="@string/copyURL" />

--- a/app/src/main/java/com/maxwai/nclientv3/FavoriteActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/FavoriteActivity.java
@@ -142,7 +142,7 @@ public class FavoriteActivity extends BaseActivity {
             adapter.setSortByTitle(sortByTitle);
             item.setTitle(sortByTitle ? R.string.sort_by_latest : R.string.sort_by_title);
         } else if (item.getItemId() == R.id.random_favorite) {
-            adapter.randomGallery();
+            startActivity(new Intent(this, RandomFavoriteActivity.class));
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/maxwai/nclientv3/RandomFavoriteActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/RandomFavoriteActivity.java
@@ -1,0 +1,137 @@
+package com.maxwai.nclientv3;
+
+import android.content.Intent;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ImageButton;
+import android.widget.TextView;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
+
+import com.maxwai.nclientv3.api.components.Gallery;
+import com.maxwai.nclientv3.async.database.Queries;
+import com.maxwai.nclientv3.components.activities.GeneralActivity;
+import com.maxwai.nclientv3.settings.Favorites;
+import com.maxwai.nclientv3.settings.Global;
+import com.maxwai.nclientv3.utility.ImageDownloadUtility;
+import com.maxwai.nclientv3.utility.Utility;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class RandomFavoriteActivity extends GeneralActivity {
+
+    private Gallery loadedGallery = null;
+    private TextView language;
+    private ImageButton thumbnail;
+    private ImageButton favorite;
+    private TextView title;
+    private TextView page;
+    private View censor;
+    private boolean isFavorite;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_random);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        FloatingActionButton shuffle = findViewById(R.id.shuffle);
+        ImageButton share = findViewById(R.id.share);
+        censor = findViewById(R.id.censor);
+        language = findViewById(R.id.language);
+        thumbnail = findViewById(R.id.thumbnail);
+        favorite = findViewById(R.id.favorite);
+        title = findViewById(R.id.title);
+        page = findViewById(R.id.pages);
+
+        setSupportActionBar(toolbar);
+        ActionBar actionBar = Objects.requireNonNull(getSupportActionBar());
+        actionBar.setDisplayHomeAsUpEnabled(true);
+        actionBar.setDisplayShowTitleEnabled(true);
+        actionBar.setTitle(R.string.random_favorite);
+
+        loadRandomGallery();
+
+        shuffle.setOnClickListener(v -> loadRandomGallery());
+
+        thumbnail.setOnClickListener(v -> {
+            if (loadedGallery != null) {
+                Intent intent = new Intent(this, GalleryActivity.class);
+                intent.putExtra(getPackageName() + ".GALLERY", loadedGallery);
+                startActivity(intent);
+            }
+        });
+
+        share.setOnClickListener(v -> {
+            if (loadedGallery != null) Global.shareGallery(this, loadedGallery);
+        });
+
+        censor.setOnClickListener(v -> censor.setVisibility(View.GONE));
+
+        favorite.setOnClickListener(v -> {
+            if (loadedGallery != null) {
+                if (isFavorite) {
+                    Favorites.removeFavorite(loadedGallery);
+                    isFavorite = false;
+                } else {
+                    Favorites.addFavorite(loadedGallery);
+                    isFavorite = true;
+                }
+                updateFavoriteButton();
+            }
+        });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void loadRandomGallery() {
+        new Thread(() -> {
+            int total = Queries.FavoriteTable.countFavorite();
+            if (total < 1) return;
+            int randomIndex = Utility.RANDOM.nextInt(total);
+            Cursor c = Queries.FavoriteTable.getAllFavoriteGalleriesCursor("", false, 1, randomIndex);
+            if (c != null && c.getCount() > 0) {
+                c.moveToFirst();
+                try {
+                    Gallery g = Queries.GalleryTable.cursorToGallery(RandomFavoriteActivity.this, c);
+                    runOnUiThread(() -> loadGallery(g));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                } finally {
+                    c.close();
+                }
+            }
+        }).start();
+    }
+
+    private void loadGallery(Gallery gallery) {
+        loadedGallery = gallery;
+        if (Global.isDestroyed(this)) return;
+        ImageDownloadUtility.loadImage(this, gallery.getCover(), thumbnail);
+        language.setText(Global.getLanguageFlag(gallery.getLanguage()));
+        isFavorite = Favorites.isFavorite(loadedGallery);
+        updateFavoriteButton();
+        title.setText(gallery.getTitle());
+        page.setText(getString(R.string.page_count_format, gallery.getPageCount()));
+        censor.setVisibility(gallery.hasIgnoredTags() ? View.VISIBLE : View.GONE);
+    }
+
+    private void updateFavoriteButton() {
+        runOnUiThread(() -> {
+            ImageDownloadUtility.loadImage(isFavorite ? R.drawable.ic_favorite : R.drawable.ic_favorite_border, favorite);
+            Global.setTint(this, favorite.getDrawable());
+        });
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="applied_filters">Applied filters</string>
     <string name="show_related">Show related galleries</string>
     <string name="random_manga">Random gallery</string>
+    <string name="random_favorite">Random favorite</string>
     <string name="save_page">Save page</string>
     <string name="page_count_format" formatted="true">%d pages</string>
     <string name="upload_date_format" formatted="true">Uploaded on %s at %s</string>


### PR DESCRIPTION
## What does this PR do?

This PR adds a new `RandomFavoriteActivity` that provides random favorite selection with a UX matching the existing random gallery feature. It also fixes a bug in the Favorites tab where the random button only randomizes within the currently loaded page instead of across all favorites.

## Changes Made

- **New Feature:** Created `RandomFavoriteActivity.java` that:
  - Loads a random favorite from the entire database
  - Displays gallery details (cover, title, page count, language, tags)
  - Allows shuffling to the next random favorite
  - Supports adding/removing from favorites
  - Includes share functionality
  
- **Bug Fix:** Modified `FavoriteActivity.java` to:
  - Launch `RandomFavoriteActivity` instead of shuffling the adapter
  - Randomizes across all favorites, not just the loaded page
  
- **UI/Manifest Updates:**
  - Added `RandomFavoriteActivity` to `AndroidManifest.xml`
  - Added "Random favorite" string resource to `strings.xml`

## Why?

The random button in Favorites was limited to the currently visible/loaded items due to pagination. This change allows users to discover any random favorite from their entire collection, matching the behavior of the Random Gallery feature.

## How to Test

1. Open the Favorites tab
2. Click the random button
3. The RandomFavoriteActivity should launch with a random favorite
4. Test shuffle button to load different random favorites
5. Test favorite toggle to add/remove from favorites
6. Test share button to share the current favorite
7. Test navigation - back should return to Favorites activity

## Screenshots
| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/4a498b06-0f3c-49bf-aac6-2aa9b1a5fdf0) | ![after](https://github.com/user-attachments/assets/2ee2b7fe-3eb6-4ffc-92d7-e401b07eab04)