### PR TITLE
Fix crash when opening Downloaded galleries with missing first page

### DIFF
--- a/app/src/main/java/com/maxwai/nclientv3/api/components/GalleryData.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/components/GalleryData.java
@@ -16,6 +16,7 @@ import com.maxwai.nclientv3.api.enums.ImageType;
 import com.maxwai.nclientv3.api.enums.SpecialTagIds;
 import com.maxwai.nclientv3.api.enums.TitleType;
 import com.maxwai.nclientv3.async.database.Queries;
+import com.maxwai.nclientv3.files.PageFile;
 import com.maxwai.nclientv3.files.GalleryFolder;
 import com.maxwai.nclientv3.settings.Global;
 import com.maxwai.nclientv3.utility.LogUtility;
@@ -243,8 +244,21 @@ public class GalleryData implements Parcelable {
     public void setPageInfo(GalleryFolder folder) {
         this.pageCount = folder.getPageCount();
         if (pageCount > 0) {
-            this.cover.setImagePath(folder.getPage(1).toUri());
-            this.thumbnail.setImagePath(folder.getPage(1).toUri());
+            PageFile firstPage = folder.getPage(folder.getMin());
+            if (firstPage == null) {
+                for (PageFile page : folder) {
+                    if (page != null) {
+                        firstPage = page;
+                        break;
+                    }
+                }
+            }
+            if (firstPage != null) {
+                this.cover.setImagePath(firstPage.toUri());
+                this.thumbnail.setImagePath(firstPage.toUri());
+            } else {
+                LogUtility.w("Local gallery has page count but no readable first page", folder);
+            }
         }
     }
 


### PR DESCRIPTION
**Summary**

This PR fixes the crash that can occur when opening `Downloaded galleries` if a local gallery folder has pages on disk but the first expected page entry cannot be resolved.

This PR fixes/implements the following **bugs/features**

* [x] Bug 1: stop assuming the local gallery cover page is always available at page index `1`
* [x] Bug 2: fall back to the first readable local page before setting cover and thumbnail paths
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

The code changes in this PR are:

1. update `GalleryData.setPageInfo()` to look up the first available local page by `folder.getMin()` instead of hard-coding `folder.getPage(1)`
2. add a fallback scan across the local page entries when the minimum-index lookup still returns `null`
3. log a warning instead of crashing when a local gallery reports a page count but no readable page can be resolved

The motivation for this change comes directly from the provided crash logs. They repeatedly show `NullPointerException` in `GalleryData.setPageInfo()` while constructing a `LocalGallery` from `FakeInspector`, with `PageFile.toUri()` being called on a null page reference after tapping `Downloaded galleries`. That points to a local gallery directory whose page numbering or contents do not satisfy the old `folder.getPage(1)` assumption.

**This is still a log-driven fix rather than a reproduced local fix. I have not been able to reproduce the crash in my local runtime environment, so I cannot yet guarantee this change fully resolves issue #166 on affected devices. Further confirmation from impacted users or devices is still needed!!!**

**Test plan (required)**

* Reviewed the provided crash logs (`NClientv3_Log_260402_011014.log` and `NClientv3_Log_260402_155808.log`) and matched the repeated stack trace to `GalleryData.setPageInfo()`
* Built the app successfully with `./gradlew.bat :app:assembleDebug`
* I was not able to reproduce the crash locally, so runtime confirmation is still pending

**Code formatting**

* No special formatting changes were needed beyond the targeted code update

**Closing issues**

Fixes #166
