### PR TITLE
Fix crash when opening favorites with null paths

### DIFF
--- a/app/src/main/java/com/maxwai/nclientv3/api/components/Page.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/components/Page.java
@@ -90,7 +90,8 @@ public class Page implements Parcelable {
         } else {
             size = in.readParcelable(Size.class.getClassLoader());
         }
-        path = Uri.parse(in.readString());
+        String pathString = in.readString();
+        path = (pathString == null || pathString.isEmpty()) ? null : Uri.parse(pathString);
         String thumbString = in.readString();
         thumbPath = Objects.requireNonNull(thumbString).isEmpty() ? null : Uri.parse(thumbString);
         imageType = ImageType.values()[in.readByte()];
@@ -105,7 +106,7 @@ public class Page implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(page);
         dest.writeParcelable(size, flags);
-        dest.writeString(path.toString());
+        dest.writeString(path == null ? "" : path.toString());
         dest.writeString(thumbPath == null ? "" : thumbPath.toString());
         dest.writeByte((byte) (imageType == null ? ImageType.PAGE.ordinal() : imageType.ordinal()));
     }


### PR DESCRIPTION
## Summary
Fixes the crash when opening certain favorites. The issue was in the Page class deserialization - it wasn't handling null or empty path strings.

## Type of change
- [x] Bug fix

## Motivation and Context
Fixes #183. When a favorite had a null or empty path, the app would crash trying to parse it or serialize it back. The code was calling Uri.parse() directly without checking for null, and on the write side it'd crash calling toString() on a null object.

## How Has This Been Tested?
Tested locally with favorites that have null paths.

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation