### PR TITLE
Fix bookmarks/export issues and add bookmark subscriptions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,10 +9,8 @@ plugins {
 }
 
 val keystorePropertiesFile: File = rootProject.file("keystore.properties")
-val keystoreProperties = Properties()
-val hasReleaseKeystore = keystorePropertiesFile.isFile
-if (hasReleaseKeystore) {
-    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+val keystoreProperties = Properties().apply {
+    load(FileInputStream(keystorePropertiesFile))
 }
 
 val majorVersion = 4
@@ -23,13 +21,11 @@ val version = "${majorVersion}.${minorVersion}.${patchVersion}"
 
 android {
     signingConfigs {
-        if (hasReleaseKeystore) {
-            create("release") {
-                keyAlias = keystoreProperties["keyAlias"] as String
-                keyPassword = keystoreProperties["keyPassword"] as String
-                storeFile = file(keystoreProperties["storeFile"] as String)
-                storePassword = keystoreProperties["storePassword"] as String
-            }
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
         }
     }
     compileSdk = 36
@@ -64,9 +60,7 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
             versionNameSuffix = "-release"
             resValue("string", "app_name", "NClientV3")
-            if (hasReleaseKeystore) {
-                signingConfig = signingConfigs.getByName("release")
-            }
+            signingConfig = signingConfigs.getByName("release")
         }
         getByName("debug") {
             applicationIdSuffix = ".debug"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,10 @@ plugins {
 }
 
 val keystorePropertiesFile: File = rootProject.file("keystore.properties")
-val keystoreProperties = Properties().apply {
-    load(FileInputStream(keystorePropertiesFile))
+val keystoreProperties = Properties()
+val hasReleaseKeystore = keystorePropertiesFile.isFile
+if (hasReleaseKeystore) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 val majorVersion = 4
@@ -21,11 +23,13 @@ val version = "${majorVersion}.${minorVersion}.${patchVersion}"
 
 android {
     signingConfigs {
-        create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
+        if (hasReleaseKeystore) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
         }
     }
     compileSdk = 36
@@ -60,7 +64,9 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
             versionNameSuffix = "-release"
             resValue("string", "app_name", "NClientV3")
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
         getByName("debug") {
             applicationIdSuffix = ".debug"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,7 @@
         <activity android:name=".StatusViewerActivity" />
         <activity android:name=".HistoryActivity" />
         <activity android:name=".BookmarkActivity" />
+        <activity android:name=".SubscriptionActivity" />
         <activity android:name=".CommentActivity" />
         <activity android:name=".SearchActivity" />
         <activity

--- a/app/src/main/java/com/maxwai/nclientv3/MainActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/MainActivity.java
@@ -703,6 +703,9 @@ public class MainActivity extends BaseActivity
         } else if (item.getItemId() == R.id.bookmarks) {
             intent = new Intent(this, BookmarkActivity.class);
             startActivity(intent);
+        } else if (item.getItemId() == R.id.subscriptions) {
+            intent = new Intent(this, SubscriptionActivity.class);
+            startActivity(intent);
         } else if (item.getItemId() == R.id.history) {
             intent = new Intent(this, HistoryActivity.class);
             startActivity(intent);

--- a/app/src/main/java/com/maxwai/nclientv3/SubscriptionActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/SubscriptionActivity.java
@@ -1,6 +1,10 @@
 package com.maxwai.nclientv3;
 
+import android.graphics.Color;
 import android.os.Bundle;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.style.ForegroundColorSpan;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
@@ -73,16 +77,17 @@ public class SubscriptionActivity extends BaseActivity {
         List<Bookmark> bookmarks = Queries.BookmarkTable.getSubscribedBookmarks();
         if (bookmarks.isEmpty()) {
             adapter.restartDataset(new ArrayList<>());
-            updateProgress(0, 0);
+            updateProgress(0, 0, 0);
             refresher.setRefreshing(false);
             return;
         }
 
         refresher.setRefreshing(true);
-        updateProgress(0, bookmarks.size());
+        updateProgress(0, 0, bookmarks.size());
         executor = Executors.newFixedThreadPool(MAX_PARALLEL_REQUESTS);
         ConcurrentHashMap<Integer, GenericGallery> galleries = new ConcurrentHashMap<>();
         AtomicInteger completed = new AtomicInteger(0);
+        AtomicInteger successful = new AtomicInteger(0);
         AtomicInteger failed = new AtomicInteger(0);
         AtomicInteger initialFailures = new AtomicInteger(0);
         AtomicBoolean hasSuccess = new AtomicBoolean(false);
@@ -90,13 +95,20 @@ public class SubscriptionActivity extends BaseActivity {
 
         for (Bookmark bookmark : bookmarks) {
             executor.execute(() -> {
-                List<GenericGallery> result = loadBookmark(bookmark, hasSuccess, initialFailures, aborted, actualLoad);
+                List<GenericGallery> result = loadBookmark(bookmark, aborted);
                 if (actualLoad != loadId || isFinishing()) return;
                 if (aborted.get()) return;
                 if (result == null) {
-                    failed.incrementAndGet();
+                    int failedCount = failed.incrementAndGet();
+                    if (!hasSuccess.get() && initialFailures.incrementAndGet() >= MAX_INITIAL_FAILURES) {
+                        aborted.set(true);
+                        updateProgress(successful.get(), failedCount, bookmarks.size());
+                        showUnableToConnect(actualLoad);
+                        return;
+                    }
                 } else {
                     hasSuccess.set(true);
+                    successful.incrementAndGet();
                     for (GenericGallery gallery : result) {
                         if (gallery != null && gallery.isValid())
                             galleries.put(gallery.getId(), gallery);
@@ -105,7 +117,7 @@ public class SubscriptionActivity extends BaseActivity {
                 }
 
                 int done = completed.incrementAndGet();
-                updateProgress(done, bookmarks.size());
+                updateProgress(successful.get(), failed.get(), bookmarks.size());
                 if (done == bookmarks.size()) {
                     finishRefresh(failed.get(), bookmarks.size(), actualLoad);
                 }
@@ -113,7 +125,7 @@ public class SubscriptionActivity extends BaseActivity {
         }
     }
 
-    private List<GenericGallery> loadBookmark(Bookmark bookmark, AtomicBoolean hasSuccess, AtomicInteger initialFailures, AtomicBoolean aborted, int actualLoad) {
+    private List<GenericGallery> loadBookmark(Bookmark bookmark, AtomicBoolean aborted) {
         for (int attempt = 0; attempt < MAX_RETRIES && !aborted.get(); attempt++) {
             try {
                 InspectorV3 inspector = bookmark.createInspector(this, null);
@@ -124,11 +136,6 @@ public class SubscriptionActivity extends BaseActivity {
                 return inspector.getGalleries();
             } catch (Exception e) {
                 LogUtility.e("Subscription request failed", e);
-                if (!hasSuccess.get() && initialFailures.incrementAndGet() >= MAX_INITIAL_FAILURES) {
-                    aborted.set(true);
-                    showUnableToConnect(actualLoad);
-                    return null;
-                }
                 Utility.threadSleep(RETRY_DELAY_MS);
             }
         }
@@ -141,10 +148,26 @@ public class SubscriptionActivity extends BaseActivity {
         runOnUiThread(() -> adapter.restartDataset(sorted));
     }
 
-    private void updateProgress(int done, int total) {
+    private void updateProgress(int successful, int failed, int total) {
         runOnUiThread(() -> {
-            progressText.setText(getString(R.string.subscription_progress_format, done, total));
+            String text = getString(R.string.subscription_progress_format, successful, failed, total);
+            SpannableString spannable = new SpannableString(text);
+            String successfulText = String.valueOf(successful);
+            String failedText = String.valueOf(failed);
+            String totalText = String.valueOf(total);
+            int successfulStart = text.indexOf(successfulText);
+            int failedStart = text.indexOf(failedText, successfulStart + successfulText.length());
+            int totalStart = text.lastIndexOf(totalText);
+            setProgressSpan(spannable, successfulStart, successfulText.length(), Color.GREEN);
+            setProgressSpan(spannable, failedStart, failedText.length(), Color.RED);
+            setProgressSpan(spannable, totalStart, totalText.length(), Color.WHITE);
+            progressText.setText(spannable);
         });
+    }
+
+    private void setProgressSpan(SpannableString spannable, int start, int length, int color) {
+        if (start < 0) return;
+        spannable.setSpan(new ForegroundColorSpan(color), start, start + length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
     private void finishRefresh(int failed, int total, int actualLoad) {
@@ -152,7 +175,7 @@ public class SubscriptionActivity extends BaseActivity {
             if (actualLoad != loadId || isFinishing()) return;
             if (executor != null) executor.shutdown();
             refresher.setRefreshing(false);
-            updateProgress(total - failed, total);
+            updateProgress(total - failed, failed, total);
             if (failed == total) {
                 showError(R.string.unable_to_connect_to_the_site, v -> loadSubscriptions());
             }

--- a/app/src/main/java/com/maxwai/nclientv3/SubscriptionActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/SubscriptionActivity.java
@@ -1,0 +1,215 @@
+package com.maxwai.nclientv3;
+
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
+
+import com.google.android.material.snackbar.Snackbar;
+import com.maxwai.nclientv3.adapters.ListAdapter;
+import com.maxwai.nclientv3.api.InspectorV3;
+import com.maxwai.nclientv3.api.components.GenericGallery;
+import com.maxwai.nclientv3.async.database.Queries;
+import com.maxwai.nclientv3.components.activities.BaseActivity;
+import com.maxwai.nclientv3.components.classes.Bookmark;
+import com.maxwai.nclientv3.settings.Global;
+import com.maxwai.nclientv3.utility.LogUtility;
+import com.maxwai.nclientv3.utility.Utility;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SubscriptionActivity extends BaseActivity {
+    private static final int MAX_PARALLEL_REQUESTS = 2;
+    private static final int MAX_RETRIES = 3;
+    private static final int MAX_INITIAL_FAILURES = 5;
+    private static final long RETRY_DELAY_MS = 200;
+
+    private ListAdapter adapter;
+    private TextView progressText;
+    private ExecutorService executor;
+    private int loadId = 0;
+    private Snackbar snackbar;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_subscription);
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        ActionBar actionBar = Objects.requireNonNull(getSupportActionBar());
+        actionBar.setDisplayHomeAsUpEnabled(true);
+        actionBar.setDisplayShowTitleEnabled(true);
+        actionBar.setTitle(R.string.subscriptions);
+
+        masterLayout = findViewById(R.id.master_layout);
+        progressText = findViewById(R.id.progress_text);
+        refresher = findViewById(R.id.refresher);
+        recycler = findViewById(R.id.recycler);
+        adapter = new ListAdapter(this);
+        recycler.setAdapter(adapter);
+        recycler.setHasFixedSize(true);
+        changeLayout(getResources().getConfiguration().orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE);
+        refresher.setOnRefreshListener(this::loadSubscriptions);
+        loadSubscriptions();
+    }
+
+    private void loadSubscriptions() {
+        int actualLoad = ++loadId;
+        hideError();
+        if (executor != null) executor.shutdownNow();
+
+        List<Bookmark> bookmarks = Queries.BookmarkTable.getSubscribedBookmarks();
+        if (bookmarks.isEmpty()) {
+            adapter.restartDataset(new ArrayList<>());
+            updateProgress(0, 0);
+            refresher.setRefreshing(false);
+            return;
+        }
+
+        refresher.setRefreshing(true);
+        updateProgress(0, bookmarks.size());
+        executor = Executors.newFixedThreadPool(MAX_PARALLEL_REQUESTS);
+        ConcurrentHashMap<Integer, GenericGallery> galleries = new ConcurrentHashMap<>();
+        AtomicInteger completed = new AtomicInteger(0);
+        AtomicInteger failed = new AtomicInteger(0);
+        AtomicInteger initialFailures = new AtomicInteger(0);
+        AtomicBoolean hasSuccess = new AtomicBoolean(false);
+        AtomicBoolean aborted = new AtomicBoolean(false);
+
+        for (Bookmark bookmark : bookmarks) {
+            executor.execute(() -> {
+                List<GenericGallery> result = loadBookmark(bookmark, hasSuccess, initialFailures, aborted, actualLoad);
+                if (actualLoad != loadId || isFinishing()) return;
+                if (aborted.get()) return;
+                if (result == null) {
+                    failed.incrementAndGet();
+                } else {
+                    hasSuccess.set(true);
+                    for (GenericGallery gallery : result) {
+                        if (gallery != null && gallery.isValid())
+                            galleries.put(gallery.getId(), gallery);
+                    }
+                    updateGalleries(galleries);
+                }
+
+                int done = completed.incrementAndGet();
+                updateProgress(done, bookmarks.size());
+                if (done == bookmarks.size()) {
+                    finishRefresh(failed.get(), bookmarks.size(), actualLoad);
+                }
+            });
+        }
+    }
+
+    private List<GenericGallery> loadBookmark(Bookmark bookmark, AtomicBoolean hasSuccess, AtomicInteger initialFailures, AtomicBoolean aborted, int actualLoad) {
+        for (int attempt = 0; attempt < MAX_RETRIES && !aborted.get(); attempt++) {
+            try {
+                InspectorV3 inspector = bookmark.createInspector(this, null);
+                if (inspector == null) return null;
+                inspector.setPage(1);
+                if (!inspector.createDocument()) throw new IOException("Subscription request failed");
+                inspector.parseDocument();
+                return inspector.getGalleries();
+            } catch (Exception e) {
+                LogUtility.e("Subscription request failed", e);
+                if (!hasSuccess.get() && initialFailures.incrementAndGet() >= MAX_INITIAL_FAILURES) {
+                    aborted.set(true);
+                    showUnableToConnect(actualLoad);
+                    return null;
+                }
+                Utility.threadSleep(RETRY_DELAY_MS);
+            }
+        }
+        return null;
+    }
+
+    private void updateGalleries(ConcurrentHashMap<Integer, GenericGallery> galleryMap) {
+        List<GenericGallery> sorted = new ArrayList<>(galleryMap.values());
+        sorted.sort((a, b) -> Integer.compare(b.getId(), a.getId()));
+        runOnUiThread(() -> adapter.restartDataset(sorted));
+    }
+
+    private void updateProgress(int done, int total) {
+        runOnUiThread(() -> {
+            progressText.setText(getString(R.string.subscription_progress_format, done, total));
+        });
+    }
+
+    private void finishRefresh(int failed, int total, int actualLoad) {
+        runOnUiThread(() -> {
+            if (actualLoad != loadId || isFinishing()) return;
+            if (executor != null) executor.shutdown();
+            refresher.setRefreshing(false);
+            updateProgress(total - failed, total);
+            if (failed == total) {
+                showError(R.string.unable_to_connect_to_the_site, v -> loadSubscriptions());
+            }
+        });
+    }
+
+    private void showUnableToConnect(int actualLoad) {
+        runOnUiThread(() -> {
+            if (actualLoad != loadId || isFinishing()) return;
+            if (executor != null) executor.shutdownNow();
+            refresher.setRefreshing(false);
+            showError(R.string.unable_to_connect_to_the_site, v -> loadSubscriptions());
+        });
+    }
+
+    private void hideError() {
+        runOnUiThread(() -> {
+            if (snackbar != null && snackbar.isShown()) {
+                snackbar.dismiss();
+                snackbar = null;
+            }
+        });
+    }
+
+    private void showError(int text, View.OnClickListener listener) {
+        if (listener == null) {
+            snackbar = Snackbar.make(masterLayout, text, Snackbar.LENGTH_SHORT);
+        } else {
+            snackbar = Snackbar.make(masterLayout, text, Snackbar.LENGTH_INDEFINITE);
+            snackbar.setAction(R.string.retry, listener);
+        }
+        snackbar.show();
+    }
+
+    @Override
+    protected int getPortraitColumnCount() {
+        return Global.getColPortMain();
+    }
+
+    @Override
+    protected int getLandscapeColumnCount() {
+        return Global.getColLandMain();
+    }
+
+    @Override
+    protected void onDestroy() {
+        loadId++;
+        if (executor != null) executor.shutdownNow();
+        super.onDestroy();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/java/com/maxwai/nclientv3/SubscriptionActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/SubscriptionActivity.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -36,9 +37,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class SubscriptionActivity extends BaseActivity {
     private static final int MAX_PARALLEL_REQUESTS = 2;
-    private static final int MAX_RETRIES = 3;
-    private static final int MAX_INITIAL_FAILURES = 5;
-    private static final long RETRY_DELAY_MS = 200;
+    private static final int BATCH_REQUEST_LIMIT = 8;
+    private static final int MAX_FAILURES_PER_BOOKMARK = 2;
+    private static final int MAX_CONSECUTIVE_FAILURES = 8;
+    private static final long REQUEST_DELAY_MS = 500;
+    private static final long BATCH_DELAY_MS = 60_000;
 
     private ListAdapter adapter;
     private TextView progressText;
@@ -84,62 +87,137 @@ public class SubscriptionActivity extends BaseActivity {
 
         refresher.setRefreshing(true);
         updateProgress(0, 0, bookmarks.size());
-        executor = Executors.newFixedThreadPool(MAX_PARALLEL_REQUESTS);
+        executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> loadSubscriptionBatches(bookmarks, actualLoad));
+    }
+
+    private void loadSubscriptionBatches(List<Bookmark> bookmarks, int actualLoad) {
+        List<SubscriptionTask> tasks = new ArrayList<>(bookmarks.size());
+        for (Bookmark bookmark : bookmarks) tasks.add(new SubscriptionTask(bookmark));
+
         ConcurrentHashMap<Integer, GenericGallery> galleries = new ConcurrentHashMap<>();
-        AtomicInteger completed = new AtomicInteger(0);
         AtomicInteger successful = new AtomicInteger(0);
         AtomicInteger failed = new AtomicInteger(0);
-        AtomicInteger initialFailures = new AtomicInteger(0);
-        AtomicBoolean hasSuccess = new AtomicBoolean(false);
+        AtomicInteger consecutiveFailures = new AtomicInteger(0);
         AtomicBoolean aborted = new AtomicBoolean(false);
 
-        for (Bookmark bookmark : bookmarks) {
-            executor.execute(() -> {
-                List<GenericGallery> result = loadBookmark(bookmark, aborted);
-                if (actualLoad != loadId || isFinishing()) return;
-                if (aborted.get()) return;
-                if (result == null) {
-                    int failedCount = failed.incrementAndGet();
-                    if (!hasSuccess.get() && initialFailures.incrementAndGet() >= MAX_INITIAL_FAILURES) {
-                        aborted.set(true);
-                        updateProgress(successful.get(), failedCount, bookmarks.size());
-                        showUnableToConnect(actualLoad);
-                        return;
-                    }
-                } else {
-                    hasSuccess.set(true);
-                    successful.incrementAndGet();
-                    for (GenericGallery gallery : result) {
-                        if (gallery != null && gallery.isValid())
-                            galleries.put(gallery.getId(), gallery);
-                    }
-                    updateGalleries(galleries);
-                }
+        while (actualLoad == loadId && !isFinishing() && !aborted.get()) {
+            hideError();
+            int requestsUsed = runSubscriptionWave(tasks, galleries, successful, failed, consecutiveFailures, aborted, bookmarks.size(), actualLoad);
+            if (aborted.get() || actualLoad != loadId || isFinishing()) break;
+            if (requestsUsed == 0) break;
+            if (isSubscriptionLoadComplete(tasks)) break;
+            showRateLimitPause(actualLoad);
+            Utility.threadSleep(BATCH_DELAY_MS);
+        }
 
-                int done = completed.incrementAndGet();
-                updateProgress(successful.get(), failed.get(), bookmarks.size());
-                if (done == bookmarks.size()) {
-                    finishRefresh(failed.get(), bookmarks.size(), actualLoad);
-                }
-            });
+        if (!aborted.get()) finishRefresh(failed.get(), bookmarks.size(), actualLoad);
+    }
+
+    private int runSubscriptionWave(List<SubscriptionTask> tasks, ConcurrentHashMap<Integer, GenericGallery> galleries,
+                                    AtomicInteger successful, AtomicInteger failed, AtomicInteger consecutiveFailures,
+                                    AtomicBoolean aborted, int total, int actualLoad) {
+        int requestsUsed = 0;
+        while (requestsUsed < BATCH_REQUEST_LIMIT && actualLoad == loadId && !isFinishing() && !aborted.get()) {
+            List<SubscriptionTask> batch = createNextBatch(tasks, BATCH_REQUEST_LIMIT - requestsUsed);
+            if (batch.isEmpty()) break;
+            runSubscriptionBatch(batch, galleries, successful, failed, consecutiveFailures, aborted, total, actualLoad);
+            requestsUsed += batch.size();
+        }
+        return requestsUsed;
+    }
+
+    private List<SubscriptionTask> createNextBatch(List<SubscriptionTask> tasks, int limit) {
+        List<SubscriptionTask> batch = new ArrayList<>(Math.min(limit, MAX_PARALLEL_REQUESTS));
+        addTasksToBatch(batch, tasks, 0, limit);
+        addTasksToBatch(batch, tasks, 1, limit);
+        return batch;
+    }
+
+    private void addTasksToBatch(List<SubscriptionTask> batch, List<SubscriptionTask> tasks, int failures, int limit) {
+        for (SubscriptionTask task : tasks) {
+            if (batch.size() >= limit || batch.size() >= MAX_PARALLEL_REQUESTS) return;
+            if (!task.finished && task.failures == failures) batch.add(task);
         }
     }
 
-    private List<GenericGallery> loadBookmark(Bookmark bookmark, AtomicBoolean aborted) {
-        for (int attempt = 0; attempt < MAX_RETRIES && !aborted.get(); attempt++) {
-            try {
-                InspectorV3 inspector = bookmark.createInspector(this, null);
-                if (inspector == null) return null;
-                inspector.setPage(1);
-                if (!inspector.createDocument()) throw new IOException("Subscription request failed");
-                inspector.parseDocument();
-                return inspector.getGalleries();
-            } catch (Exception e) {
-                LogUtility.e("Subscription request failed", e);
-                Utility.threadSleep(RETRY_DELAY_MS);
+    private void runSubscriptionBatch(List<SubscriptionTask> batch, ConcurrentHashMap<Integer, GenericGallery> galleries,
+                                      AtomicInteger successful, AtomicInteger failed, AtomicInteger consecutiveFailures,
+                                      AtomicBoolean aborted, int total, int actualLoad) {
+        CountDownLatch latch = new CountDownLatch(batch.size());
+        ExecutorService batchExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_REQUESTS);
+        try {
+            for (SubscriptionTask task : batch) {
+                if (aborted.get() || actualLoad != loadId || isFinishing()) {
+                    latch.countDown();
+                    continue;
+                }
+                batchExecutor.execute(() -> {
+                    try {
+                        List<GenericGallery> result = loadBookmark(task.bookmark);
+                        if (actualLoad != loadId || isFinishing() || aborted.get()) return;
+                        handleSubscriptionResult(task, result, galleries, successful, failed, consecutiveFailures, aborted, total, actualLoad);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+                Utility.threadSleep(REQUEST_DELAY_MS);
             }
+            latch.await();
+        } catch (InterruptedException e) {
+            LogUtility.d("Subscription batch interrupted", e);
+        } finally {
+            batchExecutor.shutdownNow();
         }
-        return null;
+    }
+
+    private List<GenericGallery> loadBookmark(Bookmark bookmark) {
+        try {
+            InspectorV3 inspector = bookmark.createInspector(this, null);
+            if (inspector == null) return null;
+            inspector.setPage(1);
+            if (!inspector.createDocument()) throw new IOException("Subscription request failed");
+            inspector.parseDocument();
+            return inspector.getGalleries();
+        } catch (Exception e) {
+            LogUtility.e("Subscription request failed", e);
+            return null;
+        }
+    }
+
+    private void handleSubscriptionResult(SubscriptionTask task, List<GenericGallery> result, ConcurrentHashMap<Integer, GenericGallery> galleries,
+                                          AtomicInteger successful, AtomicInteger failed, AtomicInteger consecutiveFailures,
+                                          AtomicBoolean aborted, int total, int actualLoad) {
+        if (result == null) {
+            int currentConsecutiveFailures = consecutiveFailures.incrementAndGet();
+            task.failures++;
+            if (task.failures >= MAX_FAILURES_PER_BOOKMARK) {
+                task.finished = true;
+                failed.incrementAndGet();
+                updateProgress(successful.get(), failed.get(), total);
+            }
+            if (currentConsecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                aborted.set(true);
+                showUnableToConnect(actualLoad);
+            }
+            return;
+        }
+
+        consecutiveFailures.set(0);
+        task.finished = true;
+        successful.incrementAndGet();
+        for (GenericGallery gallery : result) {
+            if (gallery != null && gallery.isValid()) galleries.put(gallery.getId(), gallery);
+        }
+        updateGalleries(galleries);
+        updateProgress(successful.get(), failed.get(), total);
+    }
+
+    private boolean isSubscriptionLoadComplete(List<SubscriptionTask> tasks) {
+        for (SubscriptionTask task : tasks) {
+            if (!task.finished) return false;
+        }
+        return true;
     }
 
     private void updateGalleries(ConcurrentHashMap<Integer, GenericGallery> galleryMap) {
@@ -191,6 +269,18 @@ public class SubscriptionActivity extends BaseActivity {
         });
     }
 
+    private void showRateLimitPause(int actualLoad) {
+        runOnUiThread(() -> {
+            if (actualLoad != loadId || isFinishing()) return;
+            snackbar = Snackbar.make(masterLayout, R.string.subscription_rate_limit_pause, Snackbar.LENGTH_INDEFINITE);
+            TextView snackbarText = snackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
+            snackbarText.setSingleLine(false);
+            snackbarText.setMaxLines(3);
+            snackbarText.setEllipsize(null);
+            snackbar.show();
+        });
+    }
+
     private void hideError() {
         runOnUiThread(() -> {
             if (snackbar != null && snackbar.isShown()) {
@@ -234,5 +324,15 @@ public class SubscriptionActivity extends BaseActivity {
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private static class SubscriptionTask {
+        final Bookmark bookmark;
+        int failures = 0;
+        boolean finished = false;
+
+        SubscriptionTask(Bookmark bookmark) {
+            this.bookmark = bookmark;
+        }
     }
 }

--- a/app/src/main/java/com/maxwai/nclientv3/adapters/BookmarkAdapter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/adapters/BookmarkAdapter.java
@@ -48,6 +48,12 @@ public class BookmarkAdapter extends RecyclerView.Adapter<BookmarkAdapter.ViewHo
         holder.pageLabel.setText(bookmarkActivity.getString(R.string.bookmark_page_format, bookmark.page));
 
         holder.deleteButton.setOnClickListener(v -> removeBookmarkAtPosition(position));
+        holder.subscriptionButton.setVisibility(bookmark.isSubscribable() ? View.VISIBLE : View.GONE);
+        holder.subscriptionButton.setImageResource(bookmark.isSubscribed() ? R.drawable.ic_star : R.drawable.ic_star_border);
+        holder.subscriptionButton.setOnClickListener(v -> {
+            bookmark.setSubscribed(!bookmark.isSubscribed());
+            notifyItemChanged(position);
+        });
 
         holder.rootLayout.setOnClickListener(v -> loadBookmark(bookmark));
     }
@@ -84,6 +90,7 @@ public class BookmarkAdapter extends RecyclerView.Adapter<BookmarkAdapter.ViewHo
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
         final AppCompatImageButton deleteButton;
+        final AppCompatImageButton subscriptionButton;
         final TextView queryText;
         final TextView pageLabel;
         final ConstraintLayout rootLayout;
@@ -91,6 +98,7 @@ public class BookmarkAdapter extends RecyclerView.Adapter<BookmarkAdapter.ViewHo
         ViewHolder(@NonNull View itemView) {
             super(itemView);
             deleteButton = itemView.findViewById(R.id.remove_button);
+            subscriptionButton = itemView.findViewById(R.id.subscription_button);
             pageLabel = itemView.findViewById(R.id.page);
             queryText = itemView.findViewById(R.id.title);
             rootLayout = itemView.findViewById(R.id.master_layout);

--- a/app/src/main/java/com/maxwai/nclientv3/async/database/DatabaseHelper.java
+++ b/app/src/main/java/com/maxwai/nclientv3/async/database/DatabaseHelper.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class DatabaseHelper extends SQLiteOpenHelper {
     static final String DATABASE_NAME = "Entries.db";
-    private static final int DATABASE_VERSION = 13;
+    private static final int DATABASE_VERSION = 14;
     private final Context context;
 
     public DatabaseHelper(Context context1) {
@@ -93,7 +93,12 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         if (oldVersion <= 10) db.execSQL(Queries.ResumeTable.CREATE_TABLE);
         if (oldVersion <= 11) updateFavoriteTable(db);
         if (oldVersion <= 12) addStatusTables(db);
+        if (oldVersion > 4 && oldVersion <= 13) addBookmarkSubscriptionColumn(db);
 
+    }
+
+    private void addBookmarkSubscriptionColumn(SQLiteDatabase db) {
+        db.execSQL("ALTER TABLE Bookmark ADD COLUMN `subscribed` INT NOT NULL DEFAULT 0");
     }
 
     private void addStatusTables(SQLiteDatabase db) {

--- a/app/src/main/java/com/maxwai/nclientv3/async/database/Queries.java
+++ b/app/src/main/java/com/maxwai/nclientv3/async/database/Queries.java
@@ -695,11 +695,13 @@ public class Queries {
         static final String PAGE = "page";
         static final String TYPE = "type";
         static final String TAG_ID = "tagId";
+        static final String SUBSCRIBED = "subscribed";
         static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS `Bookmark`(" +
             "`url` TEXT NOT NULL UNIQUE," +
             "`page` INT NOT NULL," +
             "`type` INT NOT NULL," +
-            "`tagId` INT NOT NULL" +
+            "`tagId` INT NOT NULL," +
+            "`subscribed` INT NOT NULL DEFAULT 0" +
             ");";
 
         public static void deleteBookmark(String url) {
@@ -708,34 +710,57 @@ public class Queries {
 
         public static void addBookmark(InspectorV3 inspector) {
             Tag tag = inspector.getTag();
-            ContentValues values = new ContentValues(4);
+            ContentValues values = new ContentValues(5);
             values.put(URL, inspector.getUrl());
             values.put(PAGE, inspector.getPage());
             values.put(TYPE, inspector.getRequestType().ordinal());
             values.put(TAG_ID, tag == null ? 0 : tag.getId());
+            values.put(SUBSCRIBED, 0);
             LogUtility.d("ADDED: " + inspector.getUrl());
             db.insertWithOnConflict(TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_IGNORE);
         }
 
         public static List<Bookmark> getBookmarks() {
-            String query = "SELECT * FROM " + TABLE_NAME;
-            try (Cursor cursor = db.rawQuery(query, null)) {
-                List<Bookmark> bookmarks = new ArrayList<>(cursor.getCount());
-                Bookmark b;
-                LogUtility.d("This url has " + cursor.getCount());
-                if (cursor.moveToFirst()) {
-                    do {
-                        b = new Bookmark(
-                            cursor.getString(cursor.getColumnIndex(URL)),
-                            cursor.getInt(cursor.getColumnIndex(PAGE)),
-                            ApiRequestType.values[cursor.getInt(cursor.getColumnIndex(TYPE))],
-                            cursor.getInt(cursor.getColumnIndex(TAG_ID))
-                        );
-                        bookmarks.add(b);
-                    } while (cursor.moveToNext());
-                }
-                return bookmarks;
+            return getBookmarks(null, null);
+        }
+
+        public static List<Bookmark> getSubscribedBookmarks() {
+            return getBookmarks(SUBSCRIBED + "=? AND " + TYPE + " IN (?,?)", new String[]{
+                "1",
+                String.valueOf(ApiRequestType.BYTAG.ordinal()),
+                String.valueOf(ApiRequestType.BYSEARCH.ordinal())
+            });
+        }
+
+        private static List<Bookmark> getBookmarks(String selection, String[] selectionArgs) {
+            try (Cursor cursor = db.query(TABLE_NAME, null, selection, selectionArgs, null, null, null)) {
+                return getBookmarksFromCursor(cursor);
             }
+        }
+
+        private static List<Bookmark> getBookmarksFromCursor(Cursor cursor) {
+            List<Bookmark> bookmarks = new ArrayList<>(cursor.getCount());
+            Bookmark b;
+            LogUtility.d("This url has " + cursor.getCount());
+            if (cursor.moveToFirst()) {
+                do {
+                    b = new Bookmark(
+                        cursor.getString(cursor.getColumnIndex(URL)),
+                        cursor.getInt(cursor.getColumnIndex(PAGE)),
+                        ApiRequestType.values[cursor.getInt(cursor.getColumnIndex(TYPE))],
+                        cursor.getInt(cursor.getColumnIndex(TAG_ID)),
+                        cursor.getInt(cursor.getColumnIndex(SUBSCRIBED)) == 1
+                    );
+                    bookmarks.add(b);
+                } while (cursor.moveToNext());
+            }
+            return bookmarks;
+        }
+
+        public static void setSubscribed(String url, boolean subscribed) {
+            ContentValues values = new ContentValues(1);
+            values.put(SUBSCRIBED, subscribed ? 1 : 0);
+            db.update(TABLE_NAME, values, URL + "=?", new String[]{url});
         }
     }
 

--- a/app/src/main/java/com/maxwai/nclientv3/async/database/export/Exporter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/async/database/export/Exporter.java
@@ -46,44 +46,43 @@ public class Exporter {
         SQLiteDatabase db = Database.getDatabase();
         if (db == null)
             throw new IOException("Can't export Database, don't have database connection yet");
-        try (JsonWriter writer = new JsonWriter(new OutputStreamWriter(stream))) {
-            writer.beginObject();
-            for (String s : SCHEMAS) {
-                try (Cursor cur = db.query(s, null, null, null, null, null, null)) {
-                    writer.name(s).beginArray();
-                    if (cur.moveToFirst()) {
-                        do {
-                            writer.beginObject();
-                            for (int i = 0; i < cur.getColumnCount(); i++) {
-                                writer.name(cur.getColumnName(i));
-                                if (cur.isNull(i)) {
-                                    writer.nullValue();
-                                } else {
-                                    switch (cur.getType(i)) {
-                                        case Cursor.FIELD_TYPE_INTEGER:
-                                            writer.value(cur.getLong(i));
-                                            break;
-                                        case Cursor.FIELD_TYPE_FLOAT:
-                                            writer.value(cur.getDouble(i));
-                                            break;
-                                        case Cursor.FIELD_TYPE_STRING:
-                                            writer.value(cur.getString(i));
-                                            break;
-                                        case Cursor.FIELD_TYPE_BLOB:
-                                        case Cursor.FIELD_TYPE_NULL:
-                                            break;
-                                    }
+        JsonWriter writer = new JsonWriter(new OutputStreamWriter(stream));
+        writer.beginObject();
+        for (String s : SCHEMAS) {
+            try (Cursor cur = db.query(s, null, null, null, null, null, null)) {
+                writer.name(s).beginArray();
+                if (cur.moveToFirst()) {
+                    do {
+                        writer.beginObject();
+                        for (int i = 0; i < cur.getColumnCount(); i++) {
+                            writer.name(cur.getColumnName(i));
+                            if (cur.isNull(i)) {
+                                writer.nullValue();
+                            } else {
+                                switch (cur.getType(i)) {
+                                    case Cursor.FIELD_TYPE_INTEGER:
+                                        writer.value(cur.getLong(i));
+                                        break;
+                                    case Cursor.FIELD_TYPE_FLOAT:
+                                        writer.value(cur.getDouble(i));
+                                        break;
+                                    case Cursor.FIELD_TYPE_STRING:
+                                        writer.value(cur.getString(i));
+                                        break;
+                                    case Cursor.FIELD_TYPE_BLOB:
+                                    case Cursor.FIELD_TYPE_NULL:
+                                        break;
                                 }
                             }
-                            writer.endObject();
-                        } while (cur.moveToNext());
-                    }
-                    writer.endArray();
+                        }
+                        writer.endObject();
+                    } while (cur.moveToNext());
                 }
+                writer.endArray();
             }
-            writer.endObject();
-            writer.flush();
         }
+        writer.endObject();
+        writer.flush();
     }
 
     public static String defaultExportName(SettingsActivity context) {

--- a/app/src/main/java/com/maxwai/nclientv3/async/database/export/Manager.java
+++ b/app/src/main/java/com/maxwai/nclientv3/async/database/export/Manager.java
@@ -1,9 +1,11 @@
 package com.maxwai.nclientv3.async.database.export;
 
 import android.net.Uri;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import com.maxwai.nclientv3.R;
 import com.maxwai.nclientv3.SettingsActivity;
 import com.maxwai.nclientv3.utility.LogUtility;
 
@@ -33,6 +35,7 @@ public class Manager extends Thread {
             context.runOnUiThread(end);
         } catch (IOException e) {
             LogUtility.e(e, e);
+            context.runOnUiThread(() -> Toast.makeText(context, R.string.failed, Toast.LENGTH_SHORT).show());
         }
     }
 }

--- a/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
+++ b/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
@@ -36,8 +36,13 @@ public class Bookmark {
         this.uri = Uri.parse(url);
     }
 
+    private String getSearchQuery() {
+        String query = uri.getQueryParameter("query");
+        return query == null ? uri.getQueryParameter("q") : query;
+    }
+
     public InspectorV3 createInspector(Context context, InspectorV3.InspectorResponse response) {
-        String query = uri.getQueryParameter("q");
+        String query = getSearchQuery();
         SortType popular = SortType.findFromAddition(uri.getQueryParameter("sort"));
         if (requestType == ApiRequestType.FAVORITE)
             return InspectorV3.favoriteInspector(context, query, page, response);
@@ -61,8 +66,7 @@ public class Bookmark {
             return tagVal.getType().getSingle() + ": " + tagVal.getName();
         if (requestType == ApiRequestType.FAVORITE) return "Favorite";
         if (requestType == ApiRequestType.BYSEARCH)
-            //noinspection ConcatenationWithEmptyString
-            return "" + uri.getQueryParameter("q");
+            return getSearchQuery() == null ? "" : getSearchQuery();
         if (requestType == ApiRequestType.BYALL) return "Main page";
         return "WTF";
     }

--- a/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
+++ b/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
@@ -19,16 +19,18 @@ import java.util.Collections;
 public class Bookmark {
     public final String url;
     public final int page, tag;
+    private boolean subscribed;
     private final ApiRequestType requestType;
     private final Tag tagVal;
     private final Uri uri;
 
-    public Bookmark(String url, int page, ApiRequestType requestType, int tag) {
+    public Bookmark(String url, int page, ApiRequestType requestType, int tag, boolean subscribed) {
         Tag tagVal1;
         this.url = url;
         this.page = page;
         this.requestType = requestType;
         this.tag = tag;
+        this.subscribed = subscribed;
         tagVal1 = Queries.TagTable.getTagById(this.tag);
         if (tagVal1 == null)
             tagVal1 = new Tag("english", 0, SpecialTagIds.LANGUAGE_ENGLISH, TagType.LANGUAGE, TagStatus.DEFAULT);
@@ -57,6 +59,19 @@ public class Bookmark {
 
     public void deleteBookmark() {
         Queries.BookmarkTable.deleteBookmark(url);
+    }
+
+    public boolean isSubscribable() {
+        return requestType == ApiRequestType.BYSEARCH || requestType == ApiRequestType.BYTAG;
+    }
+
+    public boolean isSubscribed() {
+        return subscribed;
+    }
+
+    public void setSubscribed(boolean subscribed) {
+        this.subscribed = subscribed;
+        Queries.BookmarkTable.setSubscribed(url, subscribed);
     }
 
     @NonNull

--- a/app/src/main/res/drawable/subscription_progress_background.xml
+++ b/app/src/main/res/drawable/subscription_progress_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurface" />
+    <corners android:radius="8dp" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/colorControlNormal" />
+</shape>

--- a/app/src/main/res/layout/activity_subscription.xml
+++ b/app/src/main/res/layout/activity_subscription.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/master_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize" />
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/refresher"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/progress_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="12dp"
+        android:background="@drawable/subscription_progress_background"
+        android:gravity="center"
+        android:minWidth="56dp"
+        android:paddingStart="10dp"
+        android:paddingTop="6dp"
+        android:paddingEnd="10dp"
+        android:paddingBottom="6dp"
+        android:text="@string/subscription_progress_empty" />
+</FrameLayout>

--- a/app/src/main/res/layout/bookmark_layout.xml
+++ b/app/src/main/res/layout/bookmark_layout.xml
@@ -20,15 +20,28 @@
             android:id="@+id/remove_button"
             android:layout_width="32dp"
             android:layout_height="32dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
             android:layout_marginBottom="8dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/bookmark_description"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/page"
-            app:layout_constraintStart_toStartOf="@+id/page"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/page"
             app:srcCompat="@drawable/ic_close" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/subscription_button"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginEnd="4dp"
+            android:layout_marginRight="4dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/subscription_description"
+            app:layout_constraintBottom_toBottomOf="@+id/remove_button"
+            app:layout_constraintEnd_toStartOf="@+id/remove_button"
+            app:layout_constraintTop_toTopOf="@+id/remove_button"
+            app:srcCompat="@drawable/ic_star_border" />
 
         <TextView
             android:id="@+id/title"
@@ -43,7 +56,7 @@
             android:gravity="center|start"
             android:minLines="2"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/page"
+            app:layout_constraintEnd_toStartOf="@+id/subscription_button"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -32,6 +32,10 @@
             android:icon="@drawable/ic_bookmark"
             android:title="@string/manage_bookmarks" />
         <item
+            android:id="@+id/subscriptions"
+            android:icon="@drawable/ic_star"
+            android:title="@string/subscriptions" />
+        <item
             android:id="@+id/history"
             android:icon="@drawable/ic_access_time"
             android:title="@string/view_history" />

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">وصف العلامة</string>
     <string name="subscriptions">الاشتراكات</string>
     <string name="subscription_description">اشتراك</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">عيِّن الاتجاه من اليسار إلى اليمين</string>
     <string name="setting_on_use_rtl">ستُعرض الصور من اليسار إلى اليمين</string>
     <string name="setting_off_use_rtl">ستُعرض الصور من اليمين إلى اليسار</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">سيِّر العلامات</string>
     <string name="bookmark_page_format">الصفحة %d</string>
     <string name="bookmark_description">وصف العلامة</string>
+    <string name="subscriptions">الاشتراكات</string>
+    <string name="subscription_description">اشتراك</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">عيِّن الاتجاه من اليسار إلى اليمين</string>
     <string name="setting_on_use_rtl">ستُعرض الصور من اليسار إلى اليمين</string>
     <string name="setting_off_use_rtl">ستُعرض الصور من اليمين إلى اليسار</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">اشتراك</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">تم الإيقاف مؤقتًا لتجنب حد المعدل. سيستمر التحميل خلال دقيقة واحدة.\nفتح معرض لن يقطع تحميل الاشتراكات.</string>
     <string name="enable_right_to_left">عيِّن الاتجاه من اليسار إلى اليمين</string>
     <string name="setting_on_use_rtl">ستُعرض الصور من اليسار إلى اليمين</string>
     <string name="setting_off_use_rtl">ستُعرض الصور من اليمين إلى اليسار</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Lesezeichen verwalten</string>
     <string name="bookmark_page_format">Seite %d</string>
     <string name="bookmark_description">Lesezeichen Beschreibung</string>
+    <string name="subscriptions">Abonnements</string>
+    <string name="subscription_description">Abonnement</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Rechts nach links aktivieren</string>
     <string name="setting_on_use_rtl">Bilder werden von rechts nach links angezeigt</string>
     <string name="setting_off_use_rtl">Bilder werden von links nach rechts angezeigt</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Lesezeichen Beschreibung</string>
     <string name="subscriptions">Abonnements</string>
     <string name="subscription_description">Abonnement</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Rechts nach links aktivieren</string>
     <string name="setting_on_use_rtl">Bilder werden von rechts nach links angezeigt</string>
     <string name="setting_off_use_rtl">Bilder werden von links nach rechts angezeigt</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Abonnement</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Pausiert, um das Ratenlimit zu vermeiden. Das Laden wird in 1 Minute fortgesetzt.\nDas Öffnen einer Galerie unterbricht das Laden der Abonnements nicht.</string>
     <string name="enable_right_to_left">Rechts nach links aktivieren</string>
     <string name="setting_on_use_rtl">Bilder werden von rechts nach links angezeigt</string>
     <string name="setting_off_use_rtl">Bilder werden von links nach rechts angezeigt</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Suscripción</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Pausado para evitar el límite de velocidad. La carga continuará en 1 minuto.\nAbrir una galería no interrumpirá la carga de suscripciones.</string>
     <string name="enable_right_to_left">Habilitar lectura de derecha a izquierda</string>
     <string name="setting_on_use_rtl">Las imágenes se mostrarán de derecha a izquierda</string>
     <string name="setting_off_use_rtl">Las imágenes se mostrarán de izquierda a derecha</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Descripción del marcador</string>
     <string name="subscriptions">Suscripciones</string>
     <string name="subscription_description">Suscripción</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Habilitar lectura de derecha a izquierda</string>
     <string name="setting_on_use_rtl">Las imágenes se mostrarán de derecha a izquierda</string>
     <string name="setting_off_use_rtl">Las imágenes se mostrarán de izquierda a derecha</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Administrar los marcadores</string>
     <string name="bookmark_page_format">Página %d</string>
     <string name="bookmark_description">Descripción del marcador</string>
+    <string name="subscriptions">Suscripciones</string>
+    <string name="subscription_description">Suscripción</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Habilitar lectura de derecha a izquierda</string>
     <string name="setting_on_use_rtl">Las imágenes se mostrarán de derecha a izquierda</string>
     <string name="setting_off_use_rtl">Las imágenes se mostrarán de izquierda a derecha</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Gérer les signets</string>
     <string name="bookmark_page_format">Page %d</string>
     <string name="bookmark_description">Description du signet</string>
+    <string name="subscriptions">Abonnements</string>
+    <string name="subscription_description">Abonnement</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Activer l\'affichage de droite à gauche</string>
     <string name="setting_on_use_rtl">Les images seront affichées de droite à gauche</string>
     <string name="setting_off_use_rtl">Les images seront affichées de gauche à droite</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Description du signet</string>
     <string name="subscriptions">Abonnements</string>
     <string name="subscription_description">Abonnement</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Activer l\'affichage de droite à gauche</string>
     <string name="setting_on_use_rtl">Les images seront affichées de droite à gauche</string>
     <string name="setting_off_use_rtl">Les images seront affichées de gauche à droite</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Abonnement</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">En pause pour éviter la limite de débit. Le chargement reprendra dans 1 minute.\nOuvrir une galerie n’interrompra pas le chargement des abonnements.</string>
     <string name="enable_right_to_left">Activer l\'affichage de droite à gauche</string>
     <string name="setting_on_use_rtl">Les images seront affichées de droite à gauche</string>
     <string name="setting_off_use_rtl">Les images seront affichées de gauche à droite</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Gestisci segnalibro</string>
     <string name="bookmark_page_format">Pagina %d</string>
     <string name="bookmark_description">Descrizione segnalibro</string>
+    <string name="subscriptions">Abbonamenti</string>
+    <string name="subscription_description">Abbonamento</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Abilita layout RTL </string>
     <string name="setting_on_use_rtl">Le immagini saranno mostrate da destra verso sinistra</string>
     <string name="setting_off_use_rtl">Le immagini saranno mostrate da sinistra verso destra</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Descrizione segnalibro</string>
     <string name="subscriptions">Abbonamenti</string>
     <string name="subscription_description">Abbonamento</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Abilita layout RTL </string>
     <string name="setting_on_use_rtl">Le immagini saranno mostrate da destra verso sinistra</string>
     <string name="setting_off_use_rtl">Le immagini saranno mostrate da sinistra verso destra</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Abbonamento</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">In pausa per evitare il limite di frequenza. Il caricamento continuerà tra 1 minuto.\nAprire una galleria non interromperà il caricamento degli abbonamenti.</string>
     <string name="enable_right_to_left">Abilita layout RTL </string>
     <string name="setting_on_use_rtl">Le immagini saranno mostrate da destra verso sinistra</string>
     <string name="setting_off_use_rtl">Le immagini saranno mostrate da sinistra verso destra</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">ブックマークを管理</string>
     <string name="bookmark_page_format">ページ %d</string>
     <string name="bookmark_description">ブックマークの説明</string>
+    <string name="subscriptions">購読</string>
+    <string name="subscription_description">購読</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">右から左の設定を有効</string>
     <string name="setting_on_use_rtl">画像は右から左に表示されます。</string>
     <string name="setting_off_use_rtl">画像は左から右に表示されます。</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">購読</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">レート制限を避けるため一時停止しました。1分後に読み込みを続行します。\nギャラリーを開いても購読の読み込みは中断されません。</string>
     <string name="enable_right_to_left">右から左の設定を有効</string>
     <string name="setting_on_use_rtl">画像は右から左に表示されます。</string>
     <string name="setting_off_use_rtl">画像は左から右に表示されます。</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">ブックマークの説明</string>
     <string name="subscriptions">購読</string>
     <string name="subscription_description">購読</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">右から左の設定を有効</string>
     <string name="setting_on_use_rtl">画像は右から左に表示されます。</string>
     <string name="setting_off_use_rtl">画像は左から右に表示されます。</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Descrição do marcador</string>
     <string name="subscriptions">Assinaturas</string>
     <string name="subscription_description">Assinatura</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Habilitar leitura da direita para esquerda</string>
     <string name="setting_on_use_rtl">As imagens serão exibidas da direita para a esquerda</string>
     <string name="setting_off_use_rtl">As imagens serão exibidas da esquerda para a direita</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Assinatura</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Pausado para evitar o limite de taxa. O carregamento continuará em 1 minuto.\nAbrir uma galeria não interromperá o carregamento das assinaturas.</string>
     <string name="enable_right_to_left">Habilitar leitura da direita para esquerda</string>
     <string name="setting_on_use_rtl">As imagens serão exibidas da direita para a esquerda</string>
     <string name="setting_off_use_rtl">As imagens serão exibidas da esquerda para a direita</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Gerenciar marcadores</string>
     <string name="bookmark_page_format">Página %d</string>
     <string name="bookmark_description">Descrição do marcador</string>
+    <string name="subscriptions">Assinaturas</string>
+    <string name="subscription_description">Assinatura</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Habilitar leitura da direita para esquerda</string>
     <string name="setting_on_use_rtl">As imagens serão exibidas da direita para a esquerda</string>
     <string name="setting_off_use_rtl">As imagens serão exibidas da esquerda para a direita</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Описание закладки</string>
     <string name="subscriptions">Подписки</string>
     <string name="subscription_description">Подписка</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Включить справа налево</string>
     <string name="setting_on_use_rtl">Изображения будут показываться справа налево</string>
     <string name="setting_off_use_rtl">Изображения будут показываться слева направо</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Подписка</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Приостановлено, чтобы избежать ограничения частоты. Загрузка продолжится через 1 минуту.\nОткрытие галереи не прервет загрузку подписок.</string>
     <string name="enable_right_to_left">Включить справа налево</string>
     <string name="setting_on_use_rtl">Изображения будут показываться справа налево</string>
     <string name="setting_off_use_rtl">Изображения будут показываться слева направо</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Управлять закладками</string>
     <string name="bookmark_page_format">Страница %d</string>
     <string name="bookmark_description">Описание закладки</string>
+    <string name="subscriptions">Подписки</string>
+    <string name="subscription_description">Подписка</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Включить справа налево</string>
     <string name="setting_on_use_rtl">Изображения будут показываться справа налево</string>
     <string name="setting_off_use_rtl">Изображения будут показываться слева направо</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Abonelik</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Hız sınırından kaçınmak için duraklatıldı. Yükleme 1 dakika içinde devam edecek.\nGaleri açmak abonelik yüklemesini kesintiye uğratmaz.</string>
     <string name="enable_right_to_left">Sağdan sola okumayı etkinleştir</string>
     <string name="setting_on_use_rtl">Fotoğraflar sağdan sola gösterilecek</string>
     <string name="setting_off_use_rtl">Fotoğraflar soldan sağa gösterilecek</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Yer imi açıklaması</string>
     <string name="subscriptions">Abonelikler</string>
     <string name="subscription_description">Abonelik</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Sağdan sola okumayı etkinleştir</string>
     <string name="setting_on_use_rtl">Fotoğraflar sağdan sola gösterilecek</string>
     <string name="setting_off_use_rtl">Fotoğraflar soldan sağa gösterilecek</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Yer imlerini yönet</string>
     <string name="bookmark_page_format">Sayfa %d</string>
     <string name="bookmark_description">Yer imi açıklaması</string>
+    <string name="subscriptions">Abonelikler</string>
+    <string name="subscription_description">Abonelik</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Sağdan sola okumayı etkinleştir</string>
     <string name="setting_on_use_rtl">Fotoğraflar sağdan sola gösterilecek</string>
     <string name="setting_off_use_rtl">Fotoğraflar soldan sağa gösterilecek</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">Підписка</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Призупинено, щоб уникнути обмеження частоти. Завантаження продовжиться через 1 хвилину.\nВідкриття галереї не перерве завантаження підписок.</string>
     <string name="enable_right_to_left">Увімкнути зправа на ліво</string>
     <string name="setting_on_use_rtl">Зображення будуть показуватися зправа на ліво</string>
     <string name="setting_off_use_rtl">Зображення будуть показуватися зліва направо</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">Керування закладками</string>
     <string name="bookmark_page_format">Сторінка %d</string>
     <string name="bookmark_description">Опис закладок</string>
+    <string name="subscriptions">Підписки</string>
+    <string name="subscription_description">Підписка</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Увімкнути зправа на ліво</string>
     <string name="setting_on_use_rtl">Зображення будуть показуватися зправа на ліво</string>
     <string name="setting_off_use_rtl">Зображення будуть показуватися зліва направо</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">Опис закладок</string>
     <string name="subscriptions">Підписки</string>
     <string name="subscription_description">Підписка</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Увімкнути зправа на ліво</string>
     <string name="setting_on_use_rtl">Зображення будуть показуватися зправа на ліво</string>
     <string name="setting_off_use_rtl">Зображення будуть показуватися зліва направо</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">管理书签</string>
     <string name="bookmark_page_format">第 %d 页</string>
     <string name="bookmark_description">书签描述</string>
+    <string name="subscriptions">订阅</string>
+    <string name="subscription_description">订阅</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">从右至左阅读</string>
     <string name="setting_on_use_rtl">图像将从右至左显示</string>
     <string name="setting_off_use_rtl">图像将从左至右显示</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">订阅</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">已暂停以避免触发速率限制，将在 1 分钟后继续加载。\n打开漫画不会打断订阅加载。</string>
     <string name="enable_right_to_left">从右至左阅读</string>
     <string name="setting_on_use_rtl">图像将从右至左显示</string>
     <string name="setting_off_use_rtl">图像将从左至右显示</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">书签描述</string>
     <string name="subscriptions">订阅</string>
     <string name="subscription_description">订阅</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">从右至左阅读</string>
     <string name="setting_on_use_rtl">图像将从右至左显示</string>
     <string name="setting_off_use_rtl">图像将从左至右显示</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -148,6 +148,7 @@
     <string name="subscription_description">訂閱</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">已暫停以避免觸發速率限制，將在 1 分鐘後繼續載入。\n打開漫畫不會中斷訂閱載入。</string>
     <string name="enable_right_to_left">從右至左閱讀</string>
     <string name="setting_on_use_rtl">圖像將從右至左顯示</string>
     <string name="setting_off_use_rtl">圖像將從左至右顯示</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -146,8 +146,8 @@
     <string name="bookmark_description">書籤描述</string>
     <string name="subscriptions">訂閱</string>
     <string name="subscription_description">訂閱</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">從右至左閱讀</string>
     <string name="setting_on_use_rtl">圖像將從右至左顯示</string>
     <string name="setting_off_use_rtl">圖像將從左至右顯示</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -144,6 +144,10 @@
     <string name="manage_bookmarks">管理書籤</string>
     <string name="bookmark_page_format">第 %d 頁</string>
     <string name="bookmark_description">書籤描述</string>
+    <string name="subscriptions">訂閱</string>
+    <string name="subscription_description">訂閱</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">從右至左閱讀</string>
     <string name="setting_on_use_rtl">圖像將從右至左顯示</string>
     <string name="setting_off_use_rtl">圖像將從左至右顯示</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,8 +218,8 @@
     <string name="bookmark_description">Bookmark description</string>
     <string name="subscriptions">Subscriptions</string>
     <string name="subscription_description">Subscription</string>
-    <string name="subscription_progress_empty">0 / 0</string>
-    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
+    <string name="subscription_progress_empty">0 / 0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
     <string name="enable_right_to_left">Enable right to left</string>
     <string name="setting_on_use_rtl">Images will be shown right to left</string>
     <string name="setting_off_use_rtl">Images will be shown left to right</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,10 @@
     <string name="manage_bookmarks">Manage bookmarks</string>
     <string name="bookmark_page_format">Page %d</string>
     <string name="bookmark_description">Bookmark description</string>
+    <string name="subscriptions">Subscriptions</string>
+    <string name="subscription_description">Subscription</string>
+    <string name="subscription_progress_empty">0 / 0</string>
+    <string name="subscription_progress_format" formatted="true">%1$d / %2$d</string>
     <string name="enable_right_to_left">Enable right to left</string>
     <string name="setting_on_use_rtl">Images will be shown right to left</string>
     <string name="setting_off_use_rtl">Images will be shown left to right</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,7 @@
     <string name="subscription_description">Subscription</string>
     <string name="subscription_progress_empty">0 / 0 / 0</string>
     <string name="subscription_progress_format" formatted="true">%1$d / %2$d / %3$d</string>
+    <string name="subscription_rate_limit_pause">Paused to avoid rate limit. Loading will continue in 1 minute.\nOpening a gallery will not interrupt subscription loading.</string>
     <string name="enable_right_to_left">Enable right to left</string>
     <string name="setting_on_use_rtl">Images will be shown right to left</string>
     <string name="setting_off_use_rtl">Images will be shown left to right</string>


### PR DESCRIPTION
## Summary

This PR includes two bug fixes and one new feature:

- Fix search bookmarks created from v2 API URLs by reading both `query` and legacy `q` parameters.
- Fix incomplete ZIP backups caused by closing the shared `ZipOutputStream` while exporting `Database.json`.
- Add a bookmark subscription feature:
  - users can mark search/tag bookmarks as subscribed
  - a new Subscriptions page fetches the first page of each subscribed bookmark
  - results are merged, deduplicated, and sorted by gallery id descending
  - loading progress and partial failure state are shown in the UI

## Notes

- Subscription state is stored in the bookmark table and is included in existing backup/export data.
- The new subscription fetcher uses limited parallelism and retries failed requests.
- Existing “unable to connect to the site” retry UI is reused for total failures.

## Testing

- Built debug APK locally before reverting the local-only keystore workaround.
- Manually tested bookmark display, backup export/import, and subscription loading behavior.
