### PR TITLE
Fix search bookmark query parameter

### DIFF
--- a/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
+++ b/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.maxwai.nclientv3.api.InspectorV3;
 import com.maxwai.nclientv3.api.components.Tag;
@@ -36,6 +37,7 @@ public class Bookmark {
         this.uri = Uri.parse(url);
     }
 
+    @Nullable
     private String getSearchQuery() {
         String query = uri.getQueryParameter("query");
         return query == null ? uri.getQueryParameter("q") : query;

--- a/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
+++ b/app/src/main/java/com/maxwai/nclientv3/components/classes/Bookmark.java
@@ -36,8 +36,13 @@ public class Bookmark {
         this.uri = Uri.parse(url);
     }
 
+    private String getSearchQuery() {
+        String query = uri.getQueryParameter("query");
+        return query == null ? uri.getQueryParameter("q") : query;
+    }
+
     public InspectorV3 createInspector(Context context, InspectorV3.InspectorResponse response) {
-        String query = uri.getQueryParameter("q");
+        String query = getSearchQuery();
         SortType popular = SortType.findFromAddition(uri.getQueryParameter("sort"));
         if (requestType == ApiRequestType.FAVORITE)
             return InspectorV3.favoriteInspector(context, query, page, response);
@@ -61,8 +66,7 @@ public class Bookmark {
             return tagVal.getType().getSingle() + ": " + tagVal.getName();
         if (requestType == ApiRequestType.FAVORITE) return "Favorite";
         if (requestType == ApiRequestType.BYSEARCH)
-            //noinspection ConcatenationWithEmptyString
-            return "" + uri.getQueryParameter("q");
+            return getSearchQuery() == null ? "" : getSearchQuery();
         if (requestType == ApiRequestType.BYALL) return "Main page";
         return "WTF";
     }


### PR DESCRIPTION
## Summary

Fix search bookmarks created from v2 API URLs.

The v2 search API uses the `query` parameter, while older bookmark handling only read `q`. This caused some search bookmarks to display as `null` and open the wrong/default content.

This change reads `query` first and falls back to `q` for compatibility.

## Testing

- Manually tested search bookmarks created from v2 API search URLs.
- Confirmed bookmarked searches display the expected query text and reopen the expected search results.
