### PR TITLE
Fix incomplete ZIP export

### DIFF
--- a/app/src/main/java/com/maxwai/nclientv3/async/database/export/Exporter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/async/database/export/Exporter.java
@@ -46,44 +46,44 @@ public class Exporter {
         SQLiteDatabase db = Database.getDatabase();
         if (db == null)
             throw new IOException("Can't export Database, don't have database connection yet");
-        try (JsonWriter writer = new JsonWriter(new OutputStreamWriter(stream))) {
-            writer.beginObject();
-            for (String s : SCHEMAS) {
-                try (Cursor cur = db.query(s, null, null, null, null, null, null)) {
-                    writer.name(s).beginArray();
-                    if (cur.moveToFirst()) {
-                        do {
-                            writer.beginObject();
-                            for (int i = 0; i < cur.getColumnCount(); i++) {
-                                writer.name(cur.getColumnName(i));
-                                if (cur.isNull(i)) {
-                                    writer.nullValue();
-                                } else {
-                                    switch (cur.getType(i)) {
-                                        case Cursor.FIELD_TYPE_INTEGER:
-                                            writer.value(cur.getLong(i));
-                                            break;
-                                        case Cursor.FIELD_TYPE_FLOAT:
-                                            writer.value(cur.getDouble(i));
-                                            break;
-                                        case Cursor.FIELD_TYPE_STRING:
-                                            writer.value(cur.getString(i));
-                                            break;
-                                        case Cursor.FIELD_TYPE_BLOB:
-                                        case Cursor.FIELD_TYPE_NULL:
-                                            break;
-                                    }
+        // Do not close the writer here, as that would close the shared ZipOutputStream.
+        JsonWriter writer = new JsonWriter(new OutputStreamWriter(stream));
+        writer.beginObject();
+        for (String s : SCHEMAS) {
+            try (Cursor cur = db.query(s, null, null, null, null, null, null)) {
+                writer.name(s).beginArray();
+                if (cur.moveToFirst()) {
+                    do {
+                        writer.beginObject();
+                        for (int i = 0; i < cur.getColumnCount(); i++) {
+                            writer.name(cur.getColumnName(i));
+                            if (cur.isNull(i)) {
+                                writer.nullValue();
+                            } else {
+                                switch (cur.getType(i)) {
+                                    case Cursor.FIELD_TYPE_INTEGER:
+                                        writer.value(cur.getLong(i));
+                                        break;
+                                    case Cursor.FIELD_TYPE_FLOAT:
+                                        writer.value(cur.getDouble(i));
+                                        break;
+                                    case Cursor.FIELD_TYPE_STRING:
+                                        writer.value(cur.getString(i));
+                                        break;
+                                    case Cursor.FIELD_TYPE_BLOB:
+                                    case Cursor.FIELD_TYPE_NULL:
+                                        break;
                                 }
                             }
-                            writer.endObject();
-                        } while (cur.moveToNext());
-                    }
-                    writer.endArray();
+                        }
+                        writer.endObject();
+                    } while (cur.moveToNext());
                 }
+                writer.endArray();
             }
-            writer.endObject();
-            writer.flush();
         }
+        writer.endObject();
+        writer.flush();
     }
 
     public static String defaultExportName(SettingsActivity context) {

--- a/app/src/main/java/com/maxwai/nclientv3/async/database/export/Manager.java
+++ b/app/src/main/java/com/maxwai/nclientv3/async/database/export/Manager.java
@@ -1,9 +1,11 @@
 package com.maxwai.nclientv3.async.database.export;
 
 import android.net.Uri;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import com.maxwai.nclientv3.R;
 import com.maxwai.nclientv3.SettingsActivity;
 import com.maxwai.nclientv3.utility.LogUtility;
 
@@ -33,6 +35,7 @@ public class Manager extends Thread {
             context.runOnUiThread(end);
         } catch (IOException e) {
             LogUtility.e(e, e);
+            context.runOnUiThread(() -> Toast.makeText(context, R.string.failed, Toast.LENGTH_SHORT).show());
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix incomplete backup ZIP exports.

`dumpDB()` previously used try-with-resources for `JsonWriter`. Closing the writer also closed the shared `ZipOutputStream`, so later entries such as shared preference JSON files were not written into the backup.

This change keeps the shared stream open, flushes the writer after exporting `Database.json`, and shows a failure toast if export/import fails.

## Testing

- Manually exported a backup ZIP.
- Confirmed the ZIP includes `Database.json`, `Settings.json`, and `ScrapedTags.json`.
- Manually restored the exported backup and confirmed settings are applied.
