### PR TITLE
Add minimal v2 API rate limiter

### DIFF
--- a/app/src/main/java/com/maxwai/nclientv3/MainActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/MainActivity.java
@@ -35,6 +35,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.snackbar.Snackbar;
 import com.maxwai.nclientv3.adapters.ListAdapter;
+import com.maxwai.nclientv3.api.ApiRateLimiter;
 import com.maxwai.nclientv3.api.InspectorV3;
 import com.maxwai.nclientv3.api.components.Gallery;
 import com.maxwai.nclientv3.api.components.GenericGallery;
@@ -787,7 +788,7 @@ public class MainActivity extends BaseActivity
         @Override
         public void onFailure(Exception e) {
             super.onFailure(e);
-            showError(R.string.unable_to_connect_to_the_site, v -> {
+            showError(e instanceof ApiRateLimiter.RateLimitException ? R.string.rate_limited : R.string.unable_to_connect_to_the_site, v -> {
                 inspector = inspector.cloneInspector(MainActivity.this, inspector.getResponse());
                 inspector.start();
             });

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiEndpoints.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiEndpoints.java
@@ -1,0 +1,16 @@
+package com.maxwai.nclientv3.api;
+
+public final class ApiEndpoints {
+    public static final SearchApiEndpoint SEARCH = new SearchApiEndpoint(
+        new ApiRateLimiter(
+            "GET",
+            "/api/v2/search",
+            ApiLimitConstants.SEARCH_GET_UNAUTHENTICATED_REQUEST_LIMIT,
+            ApiLimitConstants.SEARCH_GET_AUTHENTICATED_REQUEST_LIMIT,
+            ApiLimitConstants.SEARCH_GET_LIMIT_WINDOW_MS
+        )
+    );
+
+    private ApiEndpoints() {
+    }
+}

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiLimitConstants.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiLimitConstants.java
@@ -4,9 +4,16 @@ package com.maxwai.nclientv3.api;
  * Rate limit constant names are built from the API path and HTTP method.
  * Strip the /api/v2/ prefix, replace / with _, capitalize the path and append the HTTP method.
  * For example, /api/v2/part1/part2 with METHOD uses the prefix PART1_PART2_METHOD_.
+ * <p/>
+ * Each Method needs 3 constants:
+ * <ul>
+ *  <li>_LIMIT_WINDOW_MS</li>
+ *  <li>_UNAUTHENTICATED_REQUEST_LIMIT</li>
+ *  <li>_AUTHENTICATED_REQUEST_LIMIT</li>
+ * </ul>
  */
 public final class ApiLimitConstants {
-    public static final long SEARCH_GET_LIMIT_WINDOW_MS = 60_000;
+    public static final int SEARCH_GET_LIMIT_WINDOW_MS = 60_000;
     public static final int SEARCH_GET_UNAUTHENTICATED_REQUEST_LIMIT = 10;
     public static final int SEARCH_GET_AUTHENTICATED_REQUEST_LIMIT = 20;
 

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiLimitConstants.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiLimitConstants.java
@@ -1,0 +1,15 @@
+package com.maxwai.nclientv3.api;
+
+/**
+ * Rate limit constant names are built from the API path and HTTP method.
+ * Strip the /api/v2/ prefix, replace / with _, capitalize the path and append the HTTP method.
+ * For example, /api/v2/part1/part2 with METHOD uses the prefix PART1_PART2_METHOD_.
+ */
+public final class ApiLimitConstants {
+    public static final long SEARCH_GET_LIMIT_WINDOW_MS = 60_000;
+    public static final int SEARCH_GET_UNAUTHENTICATED_REQUEST_LIMIT = 10;
+    public static final int SEARCH_GET_AUTHENTICATED_REQUEST_LIMIT = 20;
+
+    private ApiLimitConstants() {
+    }
+}

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiRateLimiter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiRateLimiter.java
@@ -25,15 +25,11 @@ import okhttp3.Response;
 
 public class ApiRateLimiter {
     private static final int HTTP_TOO_MANY_REQUESTS = 429;
-    public static final Consumer<Response> CLOSE_RESPONSE_CALLBACK = Response::close;
-    public static final Consumer<IOException> LOG_FAILURE_CALLBACK = e -> LogUtility.e(e.getLocalizedMessage(), e);
-    public static final Runnable EMPTY_CANCELLED_CALLBACK = () -> {
-    };
 
     @NonNull
     private final Object lock = new Object();
     @NonNull
-    private final ArrayDeque<RequestTimestamp> recentRequests = new ArrayDeque<>();
+    private final ArrayDeque<Long> recentRequests = new ArrayDeque<>();
     @NonNull
     private final String method;
     @NonNull
@@ -65,7 +61,7 @@ public class ApiRateLimiter {
                             @NonNull Map<String, String> parameters, @Nullable RequestBody body)
         throws IOException, RateLimitException {
         Request request = buildRequest(parameters, body);
-        RequestTimestamp timestamp = reserveRequest(context);
+        long timestamp = reserveRequest(context);
         try {
             Response response = client.newCall(request).execute();
             if (response.code() == HTTP_TOO_MANY_REQUESTS) {
@@ -90,7 +86,7 @@ public class ApiRateLimiter {
                              @NonNull Consumer<RateLimitException> onRateLimited,
                              @NonNull Consumer<IOException> onFailure, @NonNull Runnable onCancelled) {
         Request request = buildRequest(parameters, body);
-        RequestTimestamp timestamp;
+        long timestamp;
         try {
             timestamp = reserveRequest(context);
         } catch (RateLimitException e) {
@@ -142,7 +138,7 @@ public class ApiRateLimiter {
         return builder.build().toString();
     }
 
-    private RequestTimestamp reserveRequest(@NonNull Context context) throws RateLimitException {
+    private long reserveRequest(@NonNull Context context) throws RateLimitException {
         synchronized (lock) {
             Date now = new Date();
             if (retryAfterUntil != null) {
@@ -161,13 +157,13 @@ public class ApiRateLimiter {
                 logRateLimitStateLocked(context, "local window block", retryAfterMs);
                 throw new RateLimitException(retryAfterMs);
             }
-            RequestTimestamp timestamp = new RequestTimestamp(System.currentTimeMillis());
+            long timestamp = System.currentTimeMillis();
             recentRequests.addLast(timestamp);
             return timestamp;
         }
     }
 
-    private void removeRequest(@NonNull RequestTimestamp timestamp) {
+    private void removeRequest(long timestamp) {
         synchronized (lock) {
             recentRequests.remove(timestamp);
         }
@@ -175,16 +171,17 @@ public class ApiRateLimiter {
 
     private void cleanWindowLocked() {
         long threshold = System.currentTimeMillis() - windowMs;
-        while (!recentRequests.isEmpty() && recentRequests.peekFirst().time <= threshold) {
+        //noinspection DataFlowIssue
+        while (!recentRequests.isEmpty() && recentRequests.peekFirst() <= threshold) {
             recentRequests.removeFirst();
         }
     }
 
     private long getRetryAfterMsLocked() {
         cleanWindowLocked();
-        RequestTimestamp firstRequest = recentRequests.peekFirst();
+        Long firstRequest = recentRequests.peekFirst();
         if (firstRequest == null) return windowMs;
-        return Math.max(0, firstRequest.time + windowMs - System.currentTimeMillis());
+        return Math.max(0, firstRequest + windowMs - System.currentTimeMillis());
     }
 
     private void setRetryAfterUntil(long retryAfterMs) {
@@ -227,14 +224,6 @@ public class ApiRateLimiter {
 
         public long getRetryAfterMs() {
             return retryAfterMs;
-        }
-    }
-
-    private static class RequestTimestamp {
-        private final long time;
-
-        RequestTimestamp(long time) {
-            this.time = time;
         }
     }
 }

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiRateLimiter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiRateLimiter.java
@@ -1,0 +1,240 @@
+package com.maxwai.nclientv3.api;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.maxwai.nclientv3.settings.AuthStore;
+import com.maxwai.nclientv3.utility.LogUtility;
+import com.maxwai.nclientv3.utility.Utility;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Date;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class ApiRateLimiter {
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+    public static final Consumer<Response> CLOSE_RESPONSE_CALLBACK = Response::close;
+    public static final Consumer<IOException> LOG_FAILURE_CALLBACK = e -> LogUtility.e(e.getLocalizedMessage(), e);
+    public static final Runnable EMPTY_CANCELLED_CALLBACK = () -> {
+    };
+
+    @NonNull
+    private final Object lock = new Object();
+    @NonNull
+    private final ArrayDeque<RequestTimestamp> recentRequests = new ArrayDeque<>();
+    @NonNull
+    private final String method;
+    @NonNull
+    private final String path;
+    private final int unauthenticatedRequestLimit;
+    private final int authenticatedRequestLimit;
+    private final long windowMs;
+    @Nullable
+    private Date retryAfterUntil;
+
+    ApiRateLimiter(@NonNull String method, @NonNull String path, int unauthenticatedRequestLimit,
+                   int authenticatedRequestLimit, long windowMs) {
+        this.method = method;
+        this.path = path;
+        this.unauthenticatedRequestLimit = unauthenticatedRequestLimit;
+        this.authenticatedRequestLimit = authenticatedRequestLimit;
+        this.windowMs = windowMs;
+    }
+
+    @NonNull
+    public Response execute(@NonNull Context context, @NonNull OkHttpClient client,
+                            @NonNull Map<String, String> parameters)
+        throws IOException, RateLimitException {
+        return execute(context, client, parameters, null);
+    }
+
+    @NonNull
+    public Response execute(@NonNull Context context, @NonNull OkHttpClient client,
+                            @NonNull Map<String, String> parameters, @Nullable RequestBody body)
+        throws IOException, RateLimitException {
+        Request request = buildRequest(parameters, body);
+        RequestTimestamp timestamp = reserveRequest(context);
+        try {
+            Response response = client.newCall(request).execute();
+            if (response.code() == HTTP_TOO_MANY_REQUESTS) {
+                removeRequest(timestamp);
+                long retryAfterMs = getLocalRetryAfterMs();
+                logRateLimitState(context, "response 429", retryAfterMs);
+                setRetryAfterUntil(retryAfterMs);
+                response.close();
+                throw new RateLimitException(retryAfterMs);
+            }
+            return response;
+        } catch (IOException e) {
+            removeRequest(timestamp);
+            throw e;
+        }
+    }
+
+    @NonNull
+    public Call executeAsync(@NonNull Context context, @NonNull OkHttpClient client,
+                             @NonNull Map<String, String> parameters, @Nullable RequestBody body,
+                             @NonNull Consumer<Response> onSuccess,
+                             @NonNull Consumer<RateLimitException> onRateLimited,
+                             @NonNull Consumer<IOException> onFailure, @NonNull Runnable onCancelled) {
+        Request request = buildRequest(parameters, body);
+        RequestTimestamp timestamp;
+        try {
+            timestamp = reserveRequest(context);
+        } catch (RateLimitException e) {
+            Call call = client.newCall(request);
+            call.cancel();
+            onRateLimited.accept(e);
+            return call;
+        }
+
+        Call call = client.newCall(request);
+        call.enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                removeRequest(timestamp);
+                if (call.isCanceled()) onCancelled.run();
+                else onFailure.accept(e);
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                if (response.code() == HTTP_TOO_MANY_REQUESTS) {
+                    removeRequest(timestamp);
+                    long retryAfterMs = getLocalRetryAfterMs();
+                    logRateLimitState(context, "async response 429", retryAfterMs);
+                    setRetryAfterUntil(retryAfterMs);
+                    onRateLimited.accept(new RateLimitException(retryAfterMs));
+                    response.close();
+                    return;
+                }
+                onSuccess.accept(response);
+            }
+        });
+        return call;
+    }
+
+    @NonNull
+    public Request buildRequest(@NonNull Map<String, String> parameters, @Nullable RequestBody body) {
+        return new Request.Builder().url(buildUrl(parameters)).method(method, body).build();
+    }
+
+    @NonNull
+    public String buildUrl(@NonNull Map<String, String> parameters) {
+        HttpUrl.Builder builder = HttpUrl.get(Utility.getBaseUrl()).newBuilder();
+        String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
+        builder.addPathSegments(normalizedPath);
+        for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+            builder.addQueryParameter(parameter.getKey(), parameter.getValue());
+        }
+        return builder.build().toString();
+    }
+
+    private RequestTimestamp reserveRequest(@NonNull Context context) throws RateLimitException {
+        synchronized (lock) {
+            Date now = new Date();
+            if (retryAfterUntil != null) {
+                if (retryAfterUntil.after(now)) {
+                    long retryAfterMs = retryAfterUntil.getTime() - now.getTime();
+                    logRateLimitStateLocked(context, "retryAfterUntil block", retryAfterMs);
+                    throw new RateLimitException(retryAfterMs);
+                }
+                retryAfterUntil = null;
+            }
+
+            cleanWindowLocked();
+            int requestLimit = AuthStore.hasValidApiKey(context) ? authenticatedRequestLimit : unauthenticatedRequestLimit;
+            if (recentRequests.size() >= requestLimit) {
+                long retryAfterMs = getRetryAfterMsLocked();
+                logRateLimitStateLocked(context, "local window block", retryAfterMs);
+                throw new RateLimitException(retryAfterMs);
+            }
+            RequestTimestamp timestamp = new RequestTimestamp(System.currentTimeMillis());
+            recentRequests.addLast(timestamp);
+            return timestamp;
+        }
+    }
+
+    private void removeRequest(@NonNull RequestTimestamp timestamp) {
+        synchronized (lock) {
+            recentRequests.remove(timestamp);
+        }
+    }
+
+    private void cleanWindowLocked() {
+        long threshold = System.currentTimeMillis() - windowMs;
+        while (!recentRequests.isEmpty() && recentRequests.peekFirst().time <= threshold) {
+            recentRequests.removeFirst();
+        }
+    }
+
+    private long getRetryAfterMsLocked() {
+        cleanWindowLocked();
+        RequestTimestamp firstRequest = recentRequests.peekFirst();
+        if (firstRequest == null) return windowMs;
+        return Math.max(0, firstRequest.time + windowMs - System.currentTimeMillis());
+    }
+
+    private void setRetryAfterUntil(long retryAfterMs) {
+        synchronized (lock) {
+            retryAfterUntil = new Date(System.currentTimeMillis() + retryAfterMs);
+        }
+    }
+
+    private long getLocalRetryAfterMs() {
+        synchronized (lock) {
+            return getRetryAfterMsLocked();
+        }
+    }
+
+    private void logRateLimitState(@NonNull Context context, @NonNull String event, long retryAfterMs) {
+        synchronized (lock) {
+            logRateLimitStateLocked(context, event, retryAfterMs);
+        }
+    }
+
+    private void logRateLimitStateLocked(@NonNull Context context, @NonNull String event, long retryAfterMs) {
+        cleanWindowLocked();
+        int requestLimit = AuthStore.hasValidApiKey(context) ? authenticatedRequestLimit : unauthenticatedRequestLimit;
+        String retryUntil = retryAfterUntil == null ? "null" : Long.toString(retryAfterUntil.getTime() - System.currentTimeMillis());
+        LogUtility.d("ApiRateLimiter " + path
+            + " event=" + event
+            + " size=" + recentRequests.size()
+            + " limit=" + requestLimit
+            + " retryAfterUntilMs=" + retryUntil
+            + " retryAfterMs=" + retryAfterMs);
+    }
+
+    public static class RateLimitException extends Exception {
+        private final long retryAfterMs;
+
+        RateLimitException(long retryAfterMs) {
+            super("API rate limited");
+            this.retryAfterMs = retryAfterMs;
+        }
+
+        public long getRetryAfterMs() {
+            return retryAfterMs;
+        }
+    }
+
+    private static class RequestTimestamp {
+        private final long time;
+
+        RequestTimestamp(long time) {
+            this.time = time;
+        }
+    }
+}

--- a/app/src/main/java/com/maxwai/nclientv3/api/InspectorV3.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/InspectorV3.java
@@ -325,6 +325,7 @@ public class InspectorV3 extends Thread implements Parcelable {
 
     @NonNull
     private Response executeDirectApiRequest(@NonNull Context context, @NonNull Request request) throws IOException {
+        // TODO: eliminate need for this method
         return Global.getClient(context).newCall(request).execute();
     }
 

--- a/app/src/main/java/com/maxwai/nclientv3/api/InspectorV3.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/InspectorV3.java
@@ -1,6 +1,7 @@
 package com.maxwai.nclientv3.api;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -237,7 +238,8 @@ public class InspectorV3 extends Thread implements Parcelable {
     public String getSearchTitle() {
         //triggered only when in searchMode
         if (!query.isEmpty()) return query;
-        return url.replace(Utility.getBaseUrl() + "api/v2/search?query=", "").replace('+', ' ');
+        String searchQuery = Uri.parse(url).getQueryParameter("query");
+        return searchQuery == null ? "" : searchQuery;
     }
 
     public void initialize(Context context, InspectorResponse response) {
@@ -292,28 +294,9 @@ public class InspectorV3 extends Thread implements Parcelable {
             if (query != null && !query.isEmpty())
                 builder.append("&q=").append(query);
         } else if (requestType == ApiRequestType.BYSEARCH || requestType == ApiRequestType.BYTAG) {
-            builder.append("search?query=").append(query);
-            for (Tag tt : tags) {
-                if (builder.toString().contains(tt.toQueryTag(TagStatus.ACCEPTED))) continue;
-                builder.append('+');
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    builder.append(URLEncoder.encode(tt.toQueryTag(), Charset.defaultCharset()));
-                } else {
-                    try {
-                        //noinspection CharsetObjectCanBeUsed
-                        builder.append(URLEncoder.encode(tt.toQueryTag(), Charset.defaultCharset().name()));
-                    } catch (UnsupportedEncodingException e) {
-                        LogUtility.wtf("This should not happen since we used the default charset", e);
-                        return;
-                    }
-                }
-            }
-            if (ranges != null)
-                builder.append('+').append(ranges.toQuery());
-            builder.append("&page=").append(page);
-            if (sortType != null && sortType.getUrlAddition() != null) {
-                builder.append("&sort=").append(sortType.getUrlAddition());
-            }
+            url = ApiEndpoints.SEARCH.buildUrl(this.query, tags, ranges, page, sortType);
+            LogUtility.d("WWW: " + getBookmarkURL());
+            return;
         }
         url = builder.toString().replace(' ', '+');
         LogUtility.d("WWW: " + getBookmarkURL());
@@ -324,12 +307,29 @@ public class InspectorV3 extends Thread implements Parcelable {
         else return url.substring(0, url.lastIndexOf('=') + 1);
     }
 
-    public boolean createDocument() throws IOException {
+    public boolean createDocument() throws IOException, ApiRateLimiter.RateLimitException {
         if (jsonResponse != null) return true;
-        try (Response response = Global.getClient(context.get()).newCall(new Request.Builder().url(url).build()).execute()) {
-            jsonResponse = response.body().string();
+        try (Response response = executeApiRequest(url)) {
+            jsonResponse = Objects.requireNonNull(response.body()).string();
             return response.code() == HttpURLConnection.HTTP_OK;
         }
+    }
+
+    @NonNull
+    private Response executeApiRequest(@NonNull String url) throws IOException, ApiRateLimiter.RateLimitException {
+        Context context = Objects.requireNonNull(this.context.get());
+        Request request = new Request.Builder().url(url).build();
+        if (isSearchRequest()) return ApiEndpoints.SEARCH.execute(context, Global.getClient(context), query, tags, ranges, page, sortType);
+        return executeDirectApiRequest(context, request);
+    }
+
+    @NonNull
+    private Response executeDirectApiRequest(@NonNull Context context, @NonNull Request request) throws IOException {
+        return Global.getClient(context).newCall(request).execute();
+    }
+
+    private boolean isSearchRequest() {
+        return requestType == ApiRequestType.BYSEARCH || requestType == ApiRequestType.BYTAG;
     }
 
     public void parseDocument() throws IOException, InvalidResponseException {
@@ -394,8 +394,9 @@ public class InspectorV3 extends Thread implements Parcelable {
         if (!v2.has("title") && v2.has("id")) {
             int galleryId = v2.getInt("id");
             String detailUrl = Utility.getBaseUrl() + "api/v2/galleries/" + galleryId + "?include=related,favorite";
-            try (Response resp = Global.getClient(context.get()).newCall(new Request.Builder().url(detailUrl).build()).execute()) {
-                String body = resp.body().string();
+            Context context = Objects.requireNonNull(this.context.get());
+            try (Response resp = executeDirectApiRequest(context, new Request.Builder().url(detailUrl).build())) {
+                String body = Objects.requireNonNull(resp.body()).string();
                 if (resp.code() != HttpURLConnection.HTTP_OK) return;
                 v2 = new JSONObject(body);
             }

--- a/app/src/main/java/com/maxwai/nclientv3/api/SearchApiEndpoint.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/SearchApiEndpoint.java
@@ -1,0 +1,78 @@
+package com.maxwai.nclientv3.api;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.maxwai.nclientv3.api.components.Ranges;
+import com.maxwai.nclientv3.api.components.Tag;
+import com.maxwai.nclientv3.api.enums.SortType;
+import com.maxwai.nclientv3.api.enums.TagStatus;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+public class SearchApiEndpoint {
+    private static final String PARAMETER_QUERY = "query";
+    private static final String PARAMETER_PAGE = "page";
+    private static final String PARAMETER_SORT = "sort";
+
+    @NonNull
+    private final ApiRateLimiter rateLimiter;
+
+    SearchApiEndpoint(@NonNull ApiRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @NonNull
+    public Response execute(@NonNull Context context, @NonNull OkHttpClient client, @Nullable String query,
+                            @Nullable Collection<Tag> tags, @Nullable Ranges ranges, int page,
+                            @Nullable SortType sortType) throws IOException, ApiRateLimiter.RateLimitException {
+        return rateLimiter.execute(context, client, buildParameters(query, tags, ranges, page, sortType));
+    }
+
+    @NonNull
+    public String buildUrl(@Nullable String query, @Nullable Collection<Tag> tags, @Nullable Ranges ranges,
+                           int page, @Nullable SortType sortType) {
+        return rateLimiter.buildUrl(buildParameters(query, tags, ranges, page, sortType));
+    }
+
+    @NonNull
+    public Map<String, String> buildParameters(@Nullable String query, @Nullable Collection<Tag> tags,
+                                               @Nullable Ranges ranges, int page, @Nullable SortType sortType) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put(PARAMETER_QUERY, buildSearchQuery(query, tags, ranges));
+        parameters.put(PARAMETER_PAGE, Integer.toString(page));
+        if (sortType != null && sortType.getUrlAddition() != null) {
+            parameters.put(PARAMETER_SORT, sortType.getUrlAddition());
+        }
+        return parameters;
+    }
+
+    @NonNull
+    private String buildSearchQuery(@Nullable String query, @Nullable Collection<Tag> tags, @Nullable Ranges ranges) {
+        StringBuilder builder = new StringBuilder(query == null ? "" : query);
+        if (tags != null) {
+            for (Tag tag : tags) {
+                if (builder.toString().contains(tag.toQueryTag(TagStatus.ACCEPTED))) continue;
+                appendSearchToken(builder, tag.toQueryTag());
+            }
+        }
+        if (ranges != null) {
+            appendSearchToken(builder, ranges.toQuery());
+        }
+        return builder.toString();
+    }
+
+    private void appendSearchToken(@NonNull StringBuilder builder, @Nullable String token) {
+        if (token == null || token.isEmpty()) return;
+        if (builder.length() > 0) builder.append(' ');
+        builder.append(token);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,6 +294,7 @@
     <string name="sort_type_title_format" formatted="true">Choose sort type (%s)</string>
     <string name="sort_select_type">Choose sort type:</string>
     <string name="unable_to_connect_to_the_site">Unable to connect to the site</string>
+    <string name="rate_limited">Rate limited. Please try again later</string>
     <string name="no_entry_found">No entries found</string>
     <string name="retry">Retry</string>
     <string name="folder_location">Folder location</string>


### PR DESCRIPTION
﻿## Summary

This is the minimal implementation discussed in #215 for the v2 API rate limiter.

It adds a reusable per-path API rate limiter and routes the first endpoint, `GET /api/v2/search`, through it.

Included scope:

- Add `ApiRateLimiter` with local sliding-window tracking.
- Add per-path limit constants in `ApiLimitConstants`.
- Add `ApiEndpoints.SEARCH` and `SearchApiEndpoint`.
- Route `BYSEARCH` and `BYTAG` requests through the search endpoint.
- Treat HTTP 429 as `RateLimitException` instead of a generic connection failure.
- Show a rate-limit message for foreground search loads.

Intentionally not included:

- Other API paths.
- Gallery detail endpoint routing.
- Bookmark compatibility changes.
- Database or import/export changes.
- Local build/keystore workaround changes.

## Validation

- Built successfully with `./gradlew :app:assemblePost28Debug`.
- Installed and smoke-tested the debug APK locally on a device.
