### PR TITLE
Add gallery detail API rate limiter

### DIFF
--- a/app/src/main/java/com/maxwai/nclientv3/GalleryActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/GalleryActivity.java
@@ -128,6 +128,13 @@ public class GalleryActivity extends BaseActivity {
             }
             InspectorV3.galleryInspector(this, id, new InspectorV3.DefaultInspectorResponse() {
                 @Override
+                public void onFailure(Exception e) {
+                    super.onFailure(e);
+                    runOnUiThread(() -> Toast.makeText(GalleryActivity.this, getRequestFailureMessage(e), Toast.LENGTH_SHORT).show());
+                    finish();
+                }
+
+                @Override
                 public void onSuccess(List<GenericGallery> galleries) {
                     if (!galleries.isEmpty()) {
                         Intent intent = new Intent(GalleryActivity.this, GalleryActivity.class);
@@ -443,6 +450,18 @@ public class GalleryActivity extends BaseActivity {
     private void toInternet() {
         refresher.setEnabled(true);
         InspectorV3.galleryInspector(this, gallery.getId(), new InspectorV3.DefaultInspectorResponse() {
+            @Override
+            public void onFailure(Exception e) {
+                super.onFailure(e);
+                if (masterLayout != null) {
+                    runOnUiThread(() -> {
+                        Snackbar snackbar = Snackbar.make(masterLayout, getRequestFailureMessage(e), Snackbar.LENGTH_SHORT);
+                        snackbar.setAction(R.string.retry, v -> toInternet());
+                        snackbar.show();
+                    });
+                }
+            }
+
             @Override
             public void onSuccess(List<GenericGallery> galleries) {
                 if (galleries.isEmpty()) return;

--- a/app/src/main/java/com/maxwai/nclientv3/MainActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/MainActivity.java
@@ -788,7 +788,7 @@ public class MainActivity extends BaseActivity
         @Override
         public void onFailure(Exception e) {
             super.onFailure(e);
-            showError(e instanceof ApiRateLimiter.RateLimitException ? R.string.rate_limited : R.string.unable_to_connect_to_the_site, v -> {
+            showError(getRequestFailureMessage(e), v -> {
                 inspector = inspector.cloneInspector(MainActivity.this, inspector.getResponse());
                 inspector.start();
             });

--- a/app/src/main/java/com/maxwai/nclientv3/adapters/ListAdapter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/adapters/ListAdapter.java
@@ -151,7 +151,7 @@ public class ListAdapter extends RecyclerView.Adapter<GenericAdapter.ViewHolder>
                     LocalAdapter.startGallery(context, file);
                 } else if (context.getMasterLayout() != null) {
                     context.runOnUiThread(() -> {
-                            Snackbar snackbar = Snackbar.make(context.getMasterLayout(), R.string.unable_to_connect_to_the_site, Snackbar.LENGTH_SHORT);
+                            Snackbar snackbar = Snackbar.make(context.getMasterLayout(), context.getRequestFailureMessage(e), Snackbar.LENGTH_SHORT);
                             snackbar.setAction(R.string.retry, v -> downloadGallery(ent));
                             snackbar.show();
                         }

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiEndpoints.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiEndpoints.java
@@ -1,6 +1,16 @@
 package com.maxwai.nclientv3.api;
 
 public final class ApiEndpoints {
+    public static final GalleryApiEndpoint GALLERY = new GalleryApiEndpoint(
+        new ApiRateLimiter(
+            "GET",
+            "/api/v2/galleries/{gallery_id}",
+            ApiLimitConstants.GALLERIES_GALLERY_ID_GET_UNAUTHENTICATED_REQUEST_LIMIT,
+            ApiLimitConstants.GALLERIES_GALLERY_ID_GET_AUTHENTICATED_REQUEST_LIMIT,
+            ApiLimitConstants.GALLERIES_GALLERY_ID_GET_LIMIT_WINDOW_MS
+        )
+    );
+
     public static final SearchApiEndpoint SEARCH = new SearchApiEndpoint(
         new ApiRateLimiter(
             "GET",

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiLimitConstants.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiLimitConstants.java
@@ -17,6 +17,10 @@ public final class ApiLimitConstants {
     public static final int SEARCH_GET_UNAUTHENTICATED_REQUEST_LIMIT = 10;
     public static final int SEARCH_GET_AUTHENTICATED_REQUEST_LIMIT = 20;
 
+    public static final int GALLERIES_GALLERY_ID_GET_LIMIT_WINDOW_MS = 60_000;
+    public static final int GALLERIES_GALLERY_ID_GET_UNAUTHENTICATED_REQUEST_LIMIT = 20;
+    public static final int GALLERIES_GALLERY_ID_GET_AUTHENTICATED_REQUEST_LIMIT = 45;
+
     private ApiLimitConstants() {
     }
 }

--- a/app/src/main/java/com/maxwai/nclientv3/api/ApiRateLimiter.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/ApiRateLimiter.java
@@ -12,6 +12,7 @@ import com.maxwai.nclientv3.utility.Utility;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -53,14 +54,22 @@ public class ApiRateLimiter {
     public Response execute(@NonNull Context context, @NonNull OkHttpClient client,
                             @NonNull Map<String, String> parameters)
         throws IOException, RateLimitException {
-        return execute(context, client, parameters, null);
+        return execute(context, client, new LinkedHashMap<>(), parameters, null);
     }
 
     @NonNull
     public Response execute(@NonNull Context context, @NonNull OkHttpClient client,
                             @NonNull Map<String, String> parameters, @Nullable RequestBody body)
         throws IOException, RateLimitException {
-        Request request = buildRequest(parameters, body);
+        return execute(context, client, new LinkedHashMap<>(), parameters, body);
+    }
+
+    @NonNull
+    public Response execute(@NonNull Context context, @NonNull OkHttpClient client,
+                            @NonNull Map<String, String> pathParameters,
+                            @NonNull Map<String, String> parameters, @Nullable RequestBody body)
+        throws IOException, RateLimitException {
+        Request request = buildRequest(pathParameters, parameters, body);
         long timestamp = reserveRequest(context);
         try {
             Response response = client.newCall(request).execute();
@@ -85,7 +94,17 @@ public class ApiRateLimiter {
                              @NonNull Consumer<Response> onSuccess,
                              @NonNull Consumer<RateLimitException> onRateLimited,
                              @NonNull Consumer<IOException> onFailure, @NonNull Runnable onCancelled) {
-        Request request = buildRequest(parameters, body);
+        return executeAsync(context, client, new LinkedHashMap<>(), parameters, body, onSuccess, onRateLimited, onFailure, onCancelled);
+    }
+
+    @NonNull
+    public Call executeAsync(@NonNull Context context, @NonNull OkHttpClient client,
+                             @NonNull Map<String, String> pathParameters,
+                             @NonNull Map<String, String> parameters, @Nullable RequestBody body,
+                             @NonNull Consumer<Response> onSuccess,
+                             @NonNull Consumer<RateLimitException> onRateLimited,
+                             @NonNull Consumer<IOException> onFailure, @NonNull Runnable onCancelled) {
+        Request request = buildRequest(pathParameters, parameters, body);
         long timestamp;
         try {
             timestamp = reserveRequest(context);
@@ -124,18 +143,39 @@ public class ApiRateLimiter {
 
     @NonNull
     public Request buildRequest(@NonNull Map<String, String> parameters, @Nullable RequestBody body) {
-        return new Request.Builder().url(buildUrl(parameters)).method(method, body).build();
+        return buildRequest(new LinkedHashMap<>(), parameters, body);
+    }
+
+    @NonNull
+    public Request buildRequest(@NonNull Map<String, String> pathParameters,
+                                @NonNull Map<String, String> parameters, @Nullable RequestBody body) {
+        return new Request.Builder().url(buildUrl(pathParameters, parameters)).method(method, body).build();
     }
 
     @NonNull
     public String buildUrl(@NonNull Map<String, String> parameters) {
+        return buildUrl(new LinkedHashMap<>(), parameters);
+    }
+
+    @NonNull
+    public String buildUrl(@NonNull Map<String, String> pathParameters, @NonNull Map<String, String> parameters) {
         HttpUrl.Builder builder = HttpUrl.get(Utility.getBaseUrl()).newBuilder();
-        String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
+        String normalizedPath = fillPathParameters(path, pathParameters);
+        if (normalizedPath.startsWith("/")) normalizedPath = normalizedPath.substring(1);
         builder.addPathSegments(normalizedPath);
         for (Map.Entry<String, String> parameter : parameters.entrySet()) {
             builder.addQueryParameter(parameter.getKey(), parameter.getValue());
         }
         return builder.build().toString();
+    }
+
+    @NonNull
+    private String fillPathParameters(@NonNull String path, @NonNull Map<String, String> pathParameters) {
+        String resolved = path;
+        for (Map.Entry<String, String> parameter : pathParameters.entrySet()) {
+            resolved = resolved.replace("{" + parameter.getKey() + "}", parameter.getValue());
+        }
+        return resolved;
     }
 
     private long reserveRequest(@NonNull Context context) throws RateLimitException {

--- a/app/src/main/java/com/maxwai/nclientv3/api/GalleryApiEndpoint.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/GalleryApiEndpoint.java
@@ -1,0 +1,50 @@
+package com.maxwai.nclientv3.api;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+public class GalleryApiEndpoint {
+    private static final String PATH_PARAMETER_GALLERY_ID = "gallery_id";
+    private static final String PARAMETER_INCLUDE = "include";
+    private static final String INCLUDE_RELATED_FAVORITE = "related,favorite";
+
+    @NonNull
+    private final ApiRateLimiter rateLimiter;
+
+    GalleryApiEndpoint(@NonNull ApiRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @NonNull
+    public Response execute(@NonNull Context context, @NonNull OkHttpClient client, int galleryId,
+                            boolean includeRelatedFavorite) throws IOException, ApiRateLimiter.RateLimitException {
+        return rateLimiter.execute(context, client, buildPathParameters(galleryId), buildParameters(includeRelatedFavorite), null);
+    }
+
+    @NonNull
+    public String buildUrl(int galleryId, boolean includeRelatedFavorite) {
+        return rateLimiter.buildUrl(buildPathParameters(galleryId), buildParameters(includeRelatedFavorite));
+    }
+
+    @NonNull
+    private Map<String, String> buildPathParameters(int galleryId) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put(PATH_PARAMETER_GALLERY_ID, Integer.toString(galleryId));
+        return parameters;
+    }
+
+    @NonNull
+    private Map<String, String> buildParameters(boolean includeRelatedFavorite) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        if (includeRelatedFavorite) parameters.put(PARAMETER_INCLUDE, INCLUDE_RELATED_FAVORITE);
+        return parameters;
+    }
+}

--- a/app/src/main/java/com/maxwai/nclientv3/api/InspectorV3.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/InspectorV3.java
@@ -288,7 +288,9 @@ public class InspectorV3 extends Thread implements Parcelable {
         } else if (requestType == ApiRequestType.RANDOM_FAVORITE) {
             builder.append("favorites/random");
         } else if (requestType == ApiRequestType.BYSINGLE) {
-            builder.append("galleries/").append(id).append("?include=related,favorite");
+            url = ApiEndpoints.GALLERY.buildUrl(id, true);
+            LogUtility.d("WWW: " + getBookmarkURL());
+            return;
         } else if (requestType == ApiRequestType.FAVORITE) {
             builder.append("favorites?page=").append(page);
             if (query != null && !query.isEmpty())
@@ -320,6 +322,7 @@ public class InspectorV3 extends Thread implements Parcelable {
         Context context = Objects.requireNonNull(this.context.get());
         Request request = new Request.Builder().url(url).build();
         if (isSearchRequest()) return ApiEndpoints.SEARCH.execute(context, Global.getClient(context), query, tags, ranges, page, sortType);
+        if (requestType == ApiRequestType.BYSINGLE) return ApiEndpoints.GALLERY.execute(context, Global.getClient(context), id, true);
         return executeDirectApiRequest(context, request);
     }
 
@@ -333,7 +336,7 @@ public class InspectorV3 extends Thread implements Parcelable {
         return requestType == ApiRequestType.BYSEARCH || requestType == ApiRequestType.BYTAG;
     }
 
-    public void parseDocument() throws IOException, InvalidResponseException {
+    public void parseDocument() throws IOException, InvalidResponseException, ApiRateLimiter.RateLimitException {
         try {
             if (requestType.isSingle()) doSingleV2();
             else doSearchV2();
@@ -386,7 +389,7 @@ public class InspectorV3 extends Thread implements Parcelable {
      * Parse single gallery from API v2 response.
      * For RANDOM, the response is just {"id": N}, so we fetch the full detail.
      */
-    private void doSingleV2() throws IOException, JSONException {
+    private void doSingleV2() throws IOException, JSONException, ApiRateLimiter.RateLimitException {
         galleries = new ArrayList<>(1);
         JSONObject v2 = new JSONObject(jsonResponse);
         if (v2.has("error")) return;
@@ -394,9 +397,8 @@ public class InspectorV3 extends Thread implements Parcelable {
         // Random endpoint returns only {"id": N} — fetch full gallery detail
         if (!v2.has("title") && v2.has("id")) {
             int galleryId = v2.getInt("id");
-            String detailUrl = Utility.getBaseUrl() + "api/v2/galleries/" + galleryId + "?include=related,favorite";
             Context context = Objects.requireNonNull(this.context.get());
-            try (Response resp = executeDirectApiRequest(context, new Request.Builder().url(detailUrl).build())) {
+            try (Response resp = ApiEndpoints.GALLERY.execute(context, Global.getClient(context), galleryId, true)) {
                 String body = Objects.requireNonNull(resp.body()).string();
                 if (resp.code() != HttpURLConnection.HTTP_OK) return;
                 v2 = new JSONObject(body);

--- a/app/src/main/java/com/maxwai/nclientv3/api/components/GalleryData.java
+++ b/app/src/main/java/com/maxwai/nclientv3/api/components/GalleryData.java
@@ -12,6 +12,8 @@ import android.util.JsonToken;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.maxwai.nclientv3.api.ApiEndpoints;
+import com.maxwai.nclientv3.api.ApiRateLimiter;
 import com.maxwai.nclientv3.api.enums.ImageType;
 import com.maxwai.nclientv3.api.enums.SpecialTagIds;
 import com.maxwai.nclientv3.api.enums.TitleType;
@@ -32,7 +34,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Objects;
 
-import okhttp3.Request;
 import okhttp3.Response;
 
 public class GalleryData implements Parcelable {
@@ -371,8 +372,7 @@ public class GalleryData implements Parcelable {
         }
         Thread updateThread = new Thread(() -> {
             // Old entry, needs to be updated
-            String detailUrl = Utility.getBaseUrl() + "api/v2/galleries/" + id;
-            try (Response resp = Global.getClient(Objects.requireNonNull(context)).newCall(new Request.Builder().url(detailUrl).build()).execute()) {
+            try (Response resp = ApiEndpoints.GALLERY.execute(Objects.requireNonNull(context), Global.getClient(context), id, false)) {
                 String body = resp.body().string();
                 if (resp.code() == HttpURLConnection.HTTP_OK) {
                     JSONObject v2 = new JSONObject(body);
@@ -390,7 +390,7 @@ public class GalleryData implements Parcelable {
                     changedInfo = false;
                     valid = false;
                 }
-            } catch (IOException | JSONException e) {
+            } catch (ApiRateLimiter.RateLimitException | IOException | JSONException e) {
                 LogUtility.e(e);
             }
         });

--- a/app/src/main/java/com/maxwai/nclientv3/components/activities/BaseActivity.java
+++ b/app/src/main/java/com/maxwai/nclientv3/components/activities/BaseActivity.java
@@ -7,6 +7,8 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import com.maxwai.nclientv3.R;
+import com.maxwai.nclientv3.api.ApiRateLimiter;
 import com.maxwai.nclientv3.components.widgets.CustomGridLayoutManager;
 
 public abstract class BaseActivity extends GeneralActivity {
@@ -29,6 +31,16 @@ public abstract class BaseActivity extends GeneralActivity {
 
     public ViewGroup getMasterLayout() {
         return masterLayout;
+    }
+
+    @NonNull
+    public String getRequestFailureMessage(@NonNull Exception e) {
+        if (e instanceof ApiRateLimiter.RateLimitException) {
+            long retryAfterMs = ((ApiRateLimiter.RateLimitException) e).getRetryAfterMs();
+            long retryAfterSeconds = Math.max(1, (retryAfterMs + 999) / 1000);
+            return getString(R.string.rate_limited_retry_after, retryAfterSeconds);
+        }
+        return getString(R.string.unable_to_connect_to_the_site);
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,6 +295,7 @@
     <string name="sort_select_type">Choose sort type:</string>
     <string name="unable_to_connect_to_the_site">Unable to connect to the site</string>
     <string name="rate_limited">Rate limited. Please try again later</string>
+    <string name="rate_limited_retry_after" formatted="true">Rate limited. Try again in %d seconds</string>
     <string name="no_entry_found">No entries found</string>
     <string name="retry">Retry</string>
     <string name="folder_location">Folder location</string>


### PR DESCRIPTION
## Summary

Adds rate-limit handling for `GET /api/v2/galleries/{gallery_id}` by routing gallery detail requests through the shared v2 API limiter.

## Changes

- Add `GalleryApiEndpoint` and register it as `ApiEndpoints.GALLERY`.
- Add path-parameter support to `ApiRateLimiter`.
- Add rate limit constants for `GET /api/v2/galleries/{gallery_id}`.
- Route normal gallery detail loads through `ApiEndpoints.GALLERY`.
- Route the follow-up detail request after `/api/v2/galleries/random` returns an id through `ApiEndpoints.GALLERY`.
- Route old gallery data page-path refreshes through `ApiEndpoints.GALLERY`.
- Show retry wait time for rate-limited foreground requests.

## Test

- Built `:app:assemblePost28Debug`.
- Installed the debug APK on device.
- Basic smoke testing did not find issues.